### PR TITLE
chore: simplify enum types (TtsLanguage, SpeechModel)

### DIFF
--- a/camb/__init__.py
+++ b/camb/__init__.py
@@ -104,8 +104,8 @@ if typing.TYPE_CHECKING:
     from .environment import CambApiEnvironment
     from .story import CreateStoryStoryPostResponse, SetupStoryStorySetupPostResponse
     from .text_to_speech import (
-        CreateStreamTtsRequestPayloadLanguage,
-        CreateStreamTtsRequestPayloadSpeechModel,
+        TtsLanguage,
+        SpeechModel,
         GetTtsResultsTtsResultsPostResponseValue,
         GetTtsRunInfoTtsResultRunIdGetResponse,
     )
@@ -124,8 +124,8 @@ _dynamic_imports: typing.Dict[str, str] = {
     "CreateStoryStoryPostResponse": ".story",
     "CreateStreamOut": ".types",
     "CreateStreamRequestPayload": ".types",
-    "CreateStreamTtsRequestPayloadLanguage": ".text_to_speech",
-    "CreateStreamTtsRequestPayloadSpeechModel": ".text_to_speech",
+    "TtsLanguage": ".text_to_speech",
+    "SpeechModel": ".text_to_speech",
     "CreateTranslatedTtsOut": ".types",
     "CreateTtsOut": ".types",
     "DataStream": ".types",
@@ -247,8 +247,8 @@ __all__ = [
     "CreateStoryStoryPostResponse",
     "CreateStreamOut",
     "CreateStreamRequestPayload",
-    "CreateStreamTtsRequestPayloadLanguage",
-    "CreateStreamTtsRequestPayloadSpeechModel",
+    "TtsLanguage",
+    "SpeechModel",
     "CreateTranslatedTtsOut",
     "CreateTtsOut",
     "DataStream",

--- a/camb/text_to_speech/__init__.py
+++ b/camb/text_to_speech/__init__.py
@@ -7,14 +7,14 @@ from importlib import import_module
 
 if typing.TYPE_CHECKING:
     from .types import (
-        CreateStreamTtsRequestPayloadLanguage,
-        CreateStreamTtsRequestPayloadSpeechModel,
+        TtsLanguage,
+        SpeechModel,
         GetTtsResultsTtsResultsPostResponseValue,
         GetTtsRunInfoTtsResultRunIdGetResponse,
     )
 _dynamic_imports: typing.Dict[str, str] = {
-    "CreateStreamTtsRequestPayloadLanguage": ".types",
-    "CreateStreamTtsRequestPayloadSpeechModel": ".types",
+    "TtsLanguage": ".types",
+    "SpeechModel": ".types",
     "GetTtsResultsTtsResultsPostResponseValue": ".types",
     "GetTtsRunInfoTtsResultRunIdGetResponse": ".types",
 }
@@ -42,8 +42,8 @@ def __dir__():
 
 
 __all__ = [
-    "CreateStreamTtsRequestPayloadLanguage",
-    "CreateStreamTtsRequestPayloadSpeechModel",
+    "TtsLanguage",
+    "SpeechModel",
     "GetTtsResultsTtsResultsPostResponseValue",
     "GetTtsRunInfoTtsResultRunIdGetResponse",
 ]

--- a/camb/text_to_speech/baseten.py
+++ b/camb/text_to_speech/baseten.py
@@ -9,8 +9,8 @@ from ..core.serialization import convert_and_respect_annotation_metadata
 from ..types.stream_tts_inference_options import StreamTtsInferenceOptions
 from ..types.stream_tts_output_configuration import StreamTtsOutputConfiguration
 from ..types.stream_tts_voice_settings import StreamTtsVoiceSettings
-from .types.create_stream_tts_request_payload_language import CreateStreamTtsRequestPayloadLanguage
-from .types.create_stream_tts_request_payload_speech_model import CreateStreamTtsRequestPayloadSpeechModel
+from .types.tts_language import TtsLanguage
+from .types.speech_model import SpeechModel
 
 OMIT = typing.cast(typing.Any, ...)
 
@@ -20,9 +20,9 @@ def baseten_tts(
     client_wrapper: SyncClientWrapper,
     *,
     text: str,
-    language: CreateStreamTtsRequestPayloadLanguage,
+    language: TtsLanguage,
     voice_id: typing.Optional[int] = OMIT,
-    speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+    speech_model: typing.Optional[SpeechModel] = OMIT,
     user_instructions: typing.Optional[str] = OMIT,
     enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
     output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,
@@ -120,9 +120,9 @@ async def async_baseten_tts(
     client_wrapper: AsyncClientWrapper,
     *,
     text: str,
-    language: CreateStreamTtsRequestPayloadLanguage,
+    language: TtsLanguage,
     voice_id: typing.Optional[int] = OMIT,
-    speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+    speech_model: typing.Optional[SpeechModel] = OMIT,
     user_instructions: typing.Optional[str] = OMIT,
     enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
     output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,

--- a/camb/text_to_speech/client.py
+++ b/camb/text_to_speech/client.py
@@ -12,8 +12,8 @@ from ..types.stream_tts_inference_options import StreamTtsInferenceOptions
 from ..types.stream_tts_output_configuration import StreamTtsOutputConfiguration
 from ..types.stream_tts_voice_settings import StreamTtsVoiceSettings
 from .raw_client import AsyncRawTextToSpeechClient, RawTextToSpeechClient
-from .types.create_stream_tts_request_payload_language import CreateStreamTtsRequestPayloadLanguage
-from .types.create_stream_tts_request_payload_speech_model import CreateStreamTtsRequestPayloadSpeechModel
+from .types.tts_language import TtsLanguage
+from .types.speech_model import SpeechModel
 from .types.get_tts_results_tts_results_post_response_value import GetTtsResultsTtsResultsPostResponseValue
 from .types.get_tts_run_info_tts_result_run_id_get_response import GetTtsRunInfoTtsResultRunIdGetResponse
 
@@ -40,9 +40,9 @@ class TextToSpeechClient:
         self,
         *,
         text: str,
-        language: CreateStreamTtsRequestPayloadLanguage,
+        language: TtsLanguage,
         voice_id: typing.Optional[int] = OMIT,
-        speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+        speech_model: typing.Optional[SpeechModel] = OMIT,
         user_instructions: typing.Optional[str] = OMIT,
         enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
         output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,
@@ -55,11 +55,11 @@ class TextToSpeechClient:
         ----------
         text : str
 
-        language : CreateStreamTtsRequestPayloadLanguage
+        language : TtsLanguage
 
         voice_id : int
 
-        speech_model : typing.Optional[CreateStreamTtsRequestPayloadSpeechModel]
+        speech_model : typing.Optional[SpeechModel]
 
         user_instructions : typing.Optional[str]
 
@@ -374,9 +374,9 @@ class AsyncTextToSpeechClient:
         self,
         *,
         text: str,
-        language: CreateStreamTtsRequestPayloadLanguage,
+        language: TtsLanguage,
         voice_id: typing.Optional[int] = OMIT,
-        speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+        speech_model: typing.Optional[SpeechModel] = OMIT,
         user_instructions: typing.Optional[str] = OMIT,
         enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
         output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,
@@ -389,11 +389,11 @@ class AsyncTextToSpeechClient:
         ----------
         text : str
 
-        language : CreateStreamTtsRequestPayloadLanguage
+        language : TtsLanguage
 
         voice_id : int
 
-        speech_model : typing.Optional[CreateStreamTtsRequestPayloadSpeechModel]
+        speech_model : typing.Optional[SpeechModel]
 
         user_instructions : typing.Optional[str]
 

--- a/camb/text_to_speech/raw_client.py
+++ b/camb/text_to_speech/raw_client.py
@@ -21,8 +21,8 @@ from ..types.stream_tts_inference_options import StreamTtsInferenceOptions
 from ..types.stream_tts_output_configuration import StreamTtsOutputConfiguration
 from ..types.stream_tts_voice_settings import StreamTtsVoiceSettings
 from .baseten import async_baseten_tts, baseten_tts
-from .types.create_stream_tts_request_payload_language import CreateStreamTtsRequestPayloadLanguage
-from .types.create_stream_tts_request_payload_speech_model import CreateStreamTtsRequestPayloadSpeechModel
+from .types.tts_language import TtsLanguage
+from .types.speech_model import SpeechModel
 from .types.get_tts_results_tts_results_post_response_value import GetTtsResultsTtsResultsPostResponseValue
 from .types.get_tts_run_info_tts_result_run_id_get_response import GetTtsRunInfoTtsResultRunIdGetResponse
 
@@ -39,9 +39,9 @@ class RawTextToSpeechClient:
         self,
         *,
         text: str,
-        language: CreateStreamTtsRequestPayloadLanguage,
+        language: TtsLanguage,
         voice_id: typing.Optional[int] = OMIT,
-        speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+        speech_model: typing.Optional[SpeechModel] = OMIT,
         user_instructions: typing.Optional[str] = OMIT,
         enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
         output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,
@@ -54,11 +54,11 @@ class RawTextToSpeechClient:
         ----------
         text : str
 
-        language : CreateStreamTtsRequestPayloadLanguage
+        language : TtsLanguage
 
         voice_id : int
 
-        speech_model : typing.Optional[CreateStreamTtsRequestPayloadSpeechModel]
+        speech_model : typing.Optional[SpeechModel]
 
         user_instructions : typing.Optional[str]
 
@@ -521,9 +521,9 @@ class AsyncRawTextToSpeechClient:
         self,
         *,
         text: str,
-        language: CreateStreamTtsRequestPayloadLanguage,
+        language: TtsLanguage,
         voice_id: typing.Optional[int] = OMIT,
-        speech_model: typing.Optional[CreateStreamTtsRequestPayloadSpeechModel] = OMIT,
+        speech_model: typing.Optional[SpeechModel] = OMIT,
         user_instructions: typing.Optional[str] = OMIT,
         enhance_named_entities_pronunciation: typing.Optional[bool] = OMIT,
         output_configuration: typing.Optional[StreamTtsOutputConfiguration] = OMIT,
@@ -536,11 +536,11 @@ class AsyncRawTextToSpeechClient:
         ----------
         text : str
 
-        language : CreateStreamTtsRequestPayloadLanguage
+        language : TtsLanguage
 
         voice_id : int
 
-        speech_model : typing.Optional[CreateStreamTtsRequestPayloadSpeechModel]
+        speech_model : typing.Optional[SpeechModel]
 
         user_instructions : typing.Optional[str]
 

--- a/camb/text_to_speech/types/__init__.py
+++ b/camb/text_to_speech/types/__init__.py
@@ -6,13 +6,13 @@ import typing
 from importlib import import_module
 
 if typing.TYPE_CHECKING:
-    from .create_stream_tts_request_payload_language import CreateStreamTtsRequestPayloadLanguage
-    from .create_stream_tts_request_payload_speech_model import CreateStreamTtsRequestPayloadSpeechModel
+    from .tts_language import TtsLanguage
+    from .speech_model import SpeechModel
     from .get_tts_results_tts_results_post_response_value import GetTtsResultsTtsResultsPostResponseValue
     from .get_tts_run_info_tts_result_run_id_get_response import GetTtsRunInfoTtsResultRunIdGetResponse
 _dynamic_imports: typing.Dict[str, str] = {
-    "CreateStreamTtsRequestPayloadLanguage": ".create_stream_tts_request_payload_language",
-    "CreateStreamTtsRequestPayloadSpeechModel": ".create_stream_tts_request_payload_speech_model",
+    "TtsLanguage": ".tts_language",
+    "SpeechModel": ".speech_model",
     "GetTtsResultsTtsResultsPostResponseValue": ".get_tts_results_tts_results_post_response_value",
     "GetTtsRunInfoTtsResultRunIdGetResponse": ".get_tts_run_info_tts_result_run_id_get_response",
 }
@@ -40,8 +40,8 @@ def __dir__():
 
 
 __all__ = [
-    "CreateStreamTtsRequestPayloadLanguage",
-    "CreateStreamTtsRequestPayloadSpeechModel",
+    "TtsLanguage",
+    "SpeechModel",
     "GetTtsResultsTtsResultsPostResponseValue",
     "GetTtsRunInfoTtsResultRunIdGetResponse",
 ]

--- a/camb/text_to_speech/types/speech_model.py
+++ b/camb/text_to_speech/types/speech_model.py
@@ -2,6 +2,6 @@
 
 import typing
 
-CreateStreamTtsRequestPayloadSpeechModel = typing.Union[
+SpeechModel = typing.Union[
     typing.Literal["mars-pro", "mars-flash", "mars-instruct"], typing.Any
 ]

--- a/camb/text_to_speech/types/tts_language.py
+++ b/camb/text_to_speech/types/tts_language.py
@@ -2,7 +2,7 @@
 
 import typing
 
-CreateStreamTtsRequestPayloadLanguage = typing.Union[
+TtsLanguage = typing.Union[
     typing.Literal[
         "ar-kw",
         "de-ch",


### PR DESCRIPTION
## Summary
- Renamed `CreateStreamTtsRequestPayloadLanguage` to `TtsLanguage` (file: `tts_language.py`)
- Renamed `CreateStreamTtsRequestPayloadSpeechModel` to `SpeechModel` (file: `speech_model.py`)
- Updated all imports, type annotations, `__all__` exports, and dynamic import mappings across `client.py`, `raw_client.py`, `baseten.py`, and all `__init__.py` files

## Test plan
- [ ] Verify imports work: `from camb import TtsLanguage, SpeechModel`
- [ ] Verify `from camb.text_to_speech import TtsLanguage, SpeechModel`
- [ ] Run existing tests to confirm no regressions