### PR TITLE
Add live transcription WebSocket client with microphone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,6 @@ Or through
 pip install git+https://github.com/Camb-ai/cambai-python-sdk
 ```
 
-Optional extras:
-
-```bash
-# Enables the live transcription Microphone helper (uses sounddevice).
-pip install "camb-sdk[microphone]"
-```
-
 ## 🔑 Authentication & Accessing Clients
 
 To use the Camb AI SDK, you'll need an API key. You can authenticate it by:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The official Python SDK for interacting with Camb AI's powerful voice and audio 
 - **Expressive Text-to-Speech**: Convert text into natural-sounding speech using a wide range of pre-existing voices.
 - **Generative Voices**: Create entirely new, unique voices from text prompts and descriptions.
 - **Soundscapes from Text**: Generate ambient audio and sound effects from textual descriptions.
+- **Live Transcription**: Stream microphone or file audio over a WebSocket and receive cumulative interim transcripts, word-level timing, and typed events.
 - Access to voice cloning, translation, and more (refer to full API documentation).
 
 ## 📦 Installation
@@ -34,6 +35,13 @@ Or through
 
 ```bash
 pip install git+https://github.com/Camb-ai/cambai-python-sdk
+```
+
+Optional extras:
+
+```bash
+# Enables the live transcription Microphone helper (uses sounddevice).
+pip install "camb-sdk[microphone]"
 ```
 
 ## 🔑 Authentication & Accessing Clients
@@ -254,6 +262,54 @@ while True:
     time.sleep(5)
 ```
 
+### 5. Live Transcription (Streaming WebSocket)
+
+Stream audio over a single WebSocket and receive cumulative interim
+transcripts, word-level timing, and typed events. The session exposes a
+microphone helper, a file source for tests, and the same `on(event)`
+dispatcher in both SDKs.
+
+```python
+import asyncio
+import os
+
+from camb.client import CambAI
+from camb.live_transcription import Microphone, ServerMessageType
+
+
+async def main():
+    client = CambAI(api_key=os.environ["CAMB_API_KEY"])
+    session = await client.live_transcription.connect(
+        model="boli-v5",
+        language="en-us",
+        sample_rate=16000,
+    )
+
+    @session.on(ServerMessageType.RESULTS)
+    def _(msg):
+        # Cumulative transcript: replace the previous interim rather
+        # than concatenating successive Results events.
+        print(f"\r{msg.transcript}", end="", flush=True)
+
+    @session.on(ServerMessageType.CLOSED)
+    def _(info):
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+
+    async with session:
+        mic = Microphone(sample_rate=16000, chunk_size=1600)
+        await session.stream_audio(mic)
+
+
+asyncio.run(main())
+```
+
+Prefer streaming a file (no audio device dependency)? See
+[`examples/live_transcription_file.py`](examples/live_transcription_file.py).
+For the full event catalog (`Ready`, `Results`, `Final`, `Error`,
+`Closed`), configuration options, and extensibility notes, see the
+[Live Transcription tutorial](https://docs.camb.ai/tutorials/live-transcription-with-sdk)
+and [SDK guide](https://docs.camb.ai/sdk-guides/live-transcription).
+
 ## ⚙️ Advanced Usage & Other Features
 
 The Camb AI SDK offers a wide range of capabilities beyond these examples, including:
@@ -262,7 +318,8 @@ The Camb AI SDK offers a wide range of capabilities beyond these examples, inclu
 - Translations
 - Translated TTS
 - Audio Dubbing
-- Transcription
+- Transcription (async file/URL jobs)
+- Live Transcription (streaming WebSocket — see Example 5 above)
 - And more!
 
 Please refer to [examples](examples/) for direct runnable examples and Official Camb AI API Documentation for a comprehensive list of features and advanced usage patterns.

--- a/camb/client.py
+++ b/camb/client.py
@@ -150,6 +150,7 @@ class CambAI:
         self._dictionaries: typing.Optional[DictionariesClient] = None
         self._project_setup: typing.Optional[ProjectSetupClient] = None
         self._deprecated_streaming: typing.Optional[DeprecatedStreamingClient] = None
+        self._live_transcription: typing.Optional[typing.Any] = None
 
     @property
     def with_raw_response(self) -> RawCambApi:
@@ -372,6 +373,14 @@ class CambAI:
             self._deprecated_streaming = DeprecatedStreamingClient(client_wrapper=self._client_wrapper)
         return self._deprecated_streaming
 
+    @property
+    def live_transcription(self):
+        if self._live_transcription is None:
+            from .live_transcription.client import LiveTranscriptionClient  # noqa: E402
+
+            self._live_transcription = LiveTranscriptionClient(client_wrapper=self._client_wrapper)
+        return self._live_transcription
+
 
 class AsyncCambAI:
     """
@@ -463,6 +472,7 @@ class AsyncCambAI:
         self._dictionaries: typing.Optional[AsyncDictionariesClient] = None
         self._project_setup: typing.Optional[AsyncProjectSetupClient] = None
         self._deprecated_streaming: typing.Optional[AsyncDeprecatedStreamingClient] = None
+        self._live_transcription: typing.Optional[typing.Any] = None
 
     @property
     def with_raw_response(self) -> AsyncRawCambApi:
@@ -708,6 +718,16 @@ class AsyncCambAI:
 
             self._deprecated_streaming = AsyncDeprecatedStreamingClient(client_wrapper=self._client_wrapper)
         return self._deprecated_streaming
+
+    @property
+    def live_transcription(self):
+        if self._live_transcription is None:
+            from .live_transcription.client import LiveTranscriptionClient  # noqa: E402
+
+            # The live transcription client is transport-agnostic; the sync
+            # wrapper carries the same api_key/base_url state we need.
+            self._live_transcription = LiveTranscriptionClient(client_wrapper=self._client_wrapper)
+        return self._live_transcription
 
 
 def _get_base_url(*, base_url: typing.Optional[str] = None, environment: CambApiEnvironment) -> str:

--- a/camb/live_transcription/__init__.py
+++ b/camb/live_transcription/__init__.py
@@ -1,0 +1,78 @@
+"""Live transcription WebSocket client.
+
+This package wraps the ``/apis/transcription/listen`` WebSocket endpoint
+documented in ``public_docs/api-reference/websockets/listen.mdx``.
+
+Quick start::
+
+    import asyncio
+    from camb.client import CambAI
+    from camb.live_transcription import Microphone, ServerMessageType
+
+    async def main():
+        client = CambAI(api_key="...")
+        session = await client.live_transcription.connect()
+
+        @session.on(ServerMessageType.RESULTS)
+        def _(msg):
+            print(msg.transcript)
+
+        async with session:
+            mic = Microphone()
+            await session.stream_audio(mic)
+
+    asyncio.run(main())
+"""
+
+from .audio_source import AudioSource, FileAudioSource
+from .client import LiveTranscriptionClient
+from .errors import (
+    LiveTranscriptionConnectError,
+    LiveTranscriptionError,
+    LiveTranscriptionProtocolError,
+    MicrophoneUnavailableError,
+)
+from .events import (
+    Alternative,
+    Channel,
+    ClosedEvent,
+    ErrorEvent,
+    FinalEvent,
+    Metadata,
+    ModelInfo,
+    PARSER_REGISTRY,
+    ReadyEvent,
+    ResultsEvent,
+    ServerMessageType,
+    Word,
+)
+from .microphone import Microphone
+from .options import ConnectOptions, Encoding
+from .session import LiveTranscriptionSession, connect
+
+__all__ = [
+    "Alternative",
+    "AudioSource",
+    "Channel",
+    "ClosedEvent",
+    "ConnectOptions",
+    "Encoding",
+    "ErrorEvent",
+    "FileAudioSource",
+    "FinalEvent",
+    "LiveTranscriptionClient",
+    "LiveTranscriptionConnectError",
+    "LiveTranscriptionError",
+    "LiveTranscriptionProtocolError",
+    "LiveTranscriptionSession",
+    "Metadata",
+    "Microphone",
+    "MicrophoneUnavailableError",
+    "ModelInfo",
+    "PARSER_REGISTRY",
+    "ReadyEvent",
+    "ResultsEvent",
+    "ServerMessageType",
+    "Word",
+    "connect",
+]

--- a/camb/live_transcription/__init__.py
+++ b/camb/live_transcription/__init__.py
@@ -30,7 +30,6 @@ from .errors import (
     LiveTranscriptionConnectError,
     LiveTranscriptionError,
     LiveTranscriptionProtocolError,
-    MicrophoneUnavailableError,
 )
 from .events import (
     Alternative,
@@ -67,7 +66,6 @@ __all__ = [
     "LiveTranscriptionSession",
     "Metadata",
     "Microphone",
-    "MicrophoneUnavailableError",
     "ModelInfo",
     "PARSER_REGISTRY",
     "ReadyEvent",

--- a/camb/live_transcription/audio_source.py
+++ b/camb/live_transcription/audio_source.py
@@ -1,0 +1,67 @@
+"""Audio sources the live transcription session can consume.
+
+An :class:`AudioSource` is anything that yields PCM byte chunks. The
+:class:`Microphone` helper is one implementation; :class:`FileAudioSource`
+is another useful for tutorials and integration tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import typing
+import wave
+
+
+class AudioSource(typing.Protocol):
+    """Async iterable of audio byte chunks ready to send over the wire."""
+
+    def __aiter__(self) -> typing.AsyncIterator[bytes]: ...
+
+    async def close(self) -> None: ...
+
+
+class FileAudioSource:
+    """Stream a 16-bit PCM WAV file as if it were a live microphone.
+
+    When ``real_time`` is true, chunks are paced to match wall-clock time so
+    consumers see arrival patterns equivalent to a live capture.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        chunk_ms: int = 100,
+        real_time: bool = True,
+    ) -> None:
+        self._path = path
+        self._chunk_ms = chunk_ms
+        self._real_time = real_time
+        self._closed = False
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        with contextlib.closing(wave.open(self._path, "rb")) as wf:
+            sample_rate = wf.getframerate()
+            channels = wf.getnchannels()
+            sample_width = wf.getsampwidth()
+            bytes_per_second = sample_rate * channels * sample_width
+            chunk_size = max(1, int(bytes_per_second * self._chunk_ms / 1000))
+
+            t0 = time.monotonic()
+            bytes_sent = 0
+            while not self._closed:
+                chunk = wf.readframes(chunk_size // (channels * sample_width))
+                if not chunk:
+                    return
+                yield chunk
+                bytes_sent += len(chunk)
+                if self._real_time:
+                    expected = bytes_sent / bytes_per_second
+                    drift = expected - (time.monotonic() - t0)
+                    if drift > 0:
+                        await asyncio.sleep(drift)
+
+    async def close(self) -> None:
+        self._closed = True

--- a/camb/live_transcription/client.py
+++ b/camb/live_transcription/client.py
@@ -1,0 +1,42 @@
+"""Resource client exposed as :attr:`CambAI.live_transcription`."""
+
+from __future__ import annotations
+
+import typing
+
+from ..core.client_wrapper import SyncClientWrapper
+from .errors import LiveTranscriptionConnectError
+from .session import LiveTranscriptionSession, connect as _connect
+
+
+class LiveTranscriptionClient:
+    """Entry point for the WebSocket live transcription stream.
+
+    Usage::
+
+        from camb.client import CambAI
+        from camb.live_transcription import ServerMessageType
+
+        client = CambAI(api_key="...")
+        async with await client.live_transcription.connect() as session:
+            @session.on(ServerMessageType.RESULTS)
+            def _(msg):
+                print(msg.transcript)
+            await session.run_until_closed()
+    """
+
+    def __init__(self, *, client_wrapper: SyncClientWrapper) -> None:
+        self._client_wrapper = client_wrapper
+
+    async def connect(self, **options: typing.Any) -> LiveTranscriptionSession:
+        api_key = self._client_wrapper.api_key
+        if not api_key:
+            raise LiveTranscriptionConnectError(
+                "CambAI was constructed without an api_key; cannot open a live transcription stream."
+            )
+        return await _connect(
+            api_key=api_key,
+            base_url=self._client_wrapper.get_base_url(),
+            extra_headers=self._client_wrapper.get_custom_headers(),
+            **options,
+        )

--- a/camb/live_transcription/errors.py
+++ b/camb/live_transcription/errors.py
@@ -1,0 +1,17 @@
+"""Exceptions raised by the live transcription client."""
+
+
+class LiveTranscriptionError(Exception):
+    """Base class for every exception raised by ``camb.live_transcription``."""
+
+
+class LiveTranscriptionConnectError(LiveTranscriptionError):
+    """The WebSocket handshake failed or the server rejected the upgrade."""
+
+
+class LiveTranscriptionProtocolError(LiveTranscriptionError):
+    """The server sent a frame the client could not decode or validate."""
+
+
+class MicrophoneUnavailableError(LiveTranscriptionError):
+    """A microphone helper was used but its optional audio dependency is missing."""

--- a/camb/live_transcription/errors.py
+++ b/camb/live_transcription/errors.py
@@ -11,7 +11,3 @@ class LiveTranscriptionConnectError(LiveTranscriptionError):
 
 class LiveTranscriptionProtocolError(LiveTranscriptionError):
     """The server sent a frame the client could not decode or validate."""
-
-
-class MicrophoneUnavailableError(LiveTranscriptionError):
-    """A microphone helper was used but its optional audio dependency is missing."""

--- a/camb/live_transcription/events.py
+++ b/camb/live_transcription/events.py
@@ -1,0 +1,129 @@
+"""Typed server events emitted over the live transcription WebSocket.
+
+Adding a new server event requires exactly three edits:
+
+1. Add a member to :class:`ServerMessageType`.
+2. Define a payload model below.
+3. Register the pair in :data:`PARSER_REGISTRY` so the session dispatcher
+   can build the typed payload for handlers.
+"""
+
+from __future__ import annotations
+
+import enum
+import typing
+
+import pydantic
+
+
+class ServerMessageType(str, enum.Enum):
+    """Stable identifiers for every event the client may dispatch to handlers."""
+
+    READY = "Ready"
+    RESULTS = "Results"
+    FINAL = "Final"
+    ERROR = "Error"
+    CLOSED = "Closed"
+
+
+class _LiveModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="allow")
+
+
+class ReadyEvent(_LiveModel):
+    """Emitted once the upstream transcription session is accepting audio."""
+
+
+class Word(_LiveModel):
+    word: str
+    start: float
+    end: float
+    confidence: float
+
+
+class Alternative(_LiveModel):
+    transcript: str = ""
+    confidence: float = 0.0
+    words: typing.List[Word] = pydantic.Field(default_factory=list)
+
+
+class Channel(_LiveModel):
+    alternatives: typing.List[Alternative] = pydantic.Field(default_factory=list)
+
+
+class ModelInfo(_LiveModel):
+    name: typing.Optional[str] = None
+    version: typing.Optional[str] = None
+
+
+class Metadata(_LiveModel):
+    request_id: typing.Optional[str] = None
+    model_uuid: typing.Optional[str] = None
+    model_info: typing.Optional[ModelInfo] = None
+
+
+class ResultsEvent(_LiveModel):
+    """Cumulative interim transcript for the current utterance.
+
+    Replace your UI state with the latest ``transcript`` rather than
+    concatenating; each event carries the full transcript so far.
+    """
+
+    is_final: bool = False
+    start: float = 0.0
+    duration: float = 0.0
+    channel: Channel
+    metadata: typing.Optional[Metadata] = None
+
+    @property
+    def transcript(self) -> str:
+        if not self.channel.alternatives:
+            return ""
+        return self.channel.alternatives[0].transcript
+
+    @property
+    def confidence(self) -> float:
+        if not self.channel.alternatives:
+            return 0.0
+        return self.channel.alternatives[0].confidence
+
+    @property
+    def words(self) -> typing.List[Word]:
+        if not self.channel.alternatives:
+            return []
+        return self.channel.alternatives[0].words
+
+
+class FinalEvent(ResultsEvent):
+    """Reserved for a future server release that emits ``is_final=True``.
+
+    The current backend never emits this. It is wired so applications can
+    register a handler today without refactoring when finals ship.
+    """
+
+    is_final: bool = True
+
+
+class ErrorEvent(_LiveModel):
+    """Server-reported error. The connection closes immediately after."""
+
+    code: typing.Optional[str] = None
+    message: str
+    raw: typing.Dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class ClosedEvent(_LiveModel):
+    """Synthetic event the SDK emits when the transport closes."""
+
+    code: int
+    reason: str = ""
+
+
+PARSER_REGISTRY: typing.Dict[ServerMessageType, typing.Type[_LiveModel]] = {
+    ServerMessageType.READY: ReadyEvent,
+    ServerMessageType.RESULTS: ResultsEvent,
+    ServerMessageType.FINAL: FinalEvent,
+    ServerMessageType.ERROR: ErrorEvent,
+    ServerMessageType.CLOSED: ClosedEvent,
+}
+"""Single source of truth mapping wire ``type`` strings to payload models."""

--- a/camb/live_transcription/microphone.py
+++ b/camb/live_transcription/microphone.py
@@ -1,13 +1,4 @@
-"""Microphone helper backed by :mod:`sounddevice` (optional extra).
-
-Install with::
-
-    pip install "camb-sdk[microphone]"
-
-The dependency is loaded lazily; importing this module without
-``sounddevice`` installed succeeds and only raises if you instantiate
-:class:`Microphone`.
-"""
+"""Microphone helper backed by :mod:`sounddevice`."""
 
 from __future__ import annotations
 
@@ -15,7 +6,7 @@ import asyncio
 import queue
 import typing
 
-from .errors import MicrophoneUnavailableError
+import sounddevice as sd
 
 
 class Microphone:
@@ -32,14 +23,6 @@ class Microphone:
         chunk_size: int = 1600,
         device: typing.Optional[typing.Union[int, str]] = None,
     ) -> None:
-        try:
-            import sounddevice  # noqa: F401
-        except ImportError as exc:
-            raise MicrophoneUnavailableError(
-                "The 'sounddevice' package is required for the Microphone helper. "
-                "Install it with: pip install 'camb-sdk[microphone]'"
-            ) from exc
-
         self._sample_rate = sample_rate
         self._chunk_size = chunk_size
         self._device = device
@@ -56,8 +39,6 @@ class Microphone:
         return self._chunk_size
 
     def start(self) -> None:
-        import sounddevice as sd
-
         if self._running:
             return
 

--- a/camb/live_transcription/microphone.py
+++ b/camb/live_transcription/microphone.py
@@ -1,0 +1,110 @@
+"""Microphone helper backed by :mod:`sounddevice` (optional extra).
+
+Install with::
+
+    pip install "camb-sdk[microphone]"
+
+The dependency is loaded lazily; importing this module without
+``sounddevice`` installed succeeds and only raises if you instantiate
+:class:`Microphone`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import typing
+
+from .errors import MicrophoneUnavailableError
+
+
+class Microphone:
+    """Capture raw 16-bit PCM audio from the default input device.
+
+    The default ``sample_rate`` and ``chunk_size`` align with the server's
+    defaults (16 kHz, 100 ms frames). Tune ``device`` to a non-default
+    input by name or ``sounddevice`` index.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        chunk_size: int = 1600,
+        device: typing.Optional[typing.Union[int, str]] = None,
+    ) -> None:
+        try:
+            import sounddevice  # noqa: F401
+        except ImportError as exc:
+            raise MicrophoneUnavailableError(
+                "The 'sounddevice' package is required for the Microphone helper. "
+                "Install it with: pip install 'camb-sdk[microphone]'"
+            ) from exc
+
+        self._sample_rate = sample_rate
+        self._chunk_size = chunk_size
+        self._device = device
+        self._queue: "queue.Queue[bytes]" = queue.Queue()
+        self._stream: typing.Any = None
+        self._running = False
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    @property
+    def chunk_size(self) -> int:
+        return self._chunk_size
+
+    def start(self) -> None:
+        import sounddevice as sd
+
+        if self._running:
+            return
+
+        def _callback(indata, _frames, _time_info, _status):  # noqa: ANN001
+            # ``indata`` is a numpy array of int16 samples. ``tobytes`` gives
+            # the little-endian byte layout the server expects (``linear16``).
+            self._queue.put(bytes(indata))
+
+        self._stream = sd.RawInputStream(
+            samplerate=self._sample_rate,
+            blocksize=self._chunk_size,
+            device=self._device,
+            dtype="int16",
+            channels=1,
+            callback=_callback,
+        )
+        self._stream.start()
+        self._running = True
+
+    def stop(self) -> None:
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+        self._running = False
+        # Sentinel so any pending consumer can unblock.
+        self._queue.put(b"")
+
+    def read(self, timeout: typing.Optional[float] = None) -> bytes:
+        return self._queue.get(timeout=timeout)
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        if not self._running:
+            self.start()
+        loop = asyncio.get_running_loop()
+        while True:
+            chunk = await loop.run_in_executor(None, self._queue.get)
+            if not chunk:
+                return
+            yield chunk
+
+    async def close(self) -> None:
+        self.stop()
+
+    def __enter__(self) -> "Microphone":
+        self.start()
+        return self
+
+    def __exit__(self, *exc: typing.Any) -> None:
+        self.stop()

--- a/camb/live_transcription/options.py
+++ b/camb/live_transcription/options.py
@@ -1,0 +1,39 @@
+"""Connection options for the live transcription WebSocket."""
+
+from __future__ import annotations
+
+import enum
+import typing
+
+import pydantic
+
+
+class Encoding(str, enum.Enum):
+    LINEAR16 = "linear16"
+    LINEAR32 = "linear32"
+    ALAW = "alaw"
+    MULAW = "mulaw"
+
+
+class ConnectOptions(pydantic.BaseModel):
+    """Query-string options sent on the WebSocket upgrade.
+
+    Defaults match the server-side defaults documented in the AsyncAPI
+    spec under ``api-reference/websockets/asyncapi.json``. Every field is
+    optional; omit any to let the server fall back to its default.
+    """
+
+    model: str = "boli-v5"
+    language: str = "en-us"
+    encoding: Encoding = Encoding.LINEAR16
+    sample_rate: int = 16000
+    channels: int = 1
+
+    def to_query(self) -> typing.Dict[str, str]:
+        return {
+            "model": self.model,
+            "language": self.language,
+            "encoding": self.encoding.value,
+            "sample_rate": str(self.sample_rate),
+            "channels": str(self.channels),
+        }

--- a/camb/live_transcription/session.py
+++ b/camb/live_transcription/session.py
@@ -1,0 +1,287 @@
+"""Live transcription session — one open WebSocket and its event pump."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import typing
+
+import pydantic
+
+from .audio_source import AudioSource
+from .errors import LiveTranscriptionProtocolError
+from .events import (
+    PARSER_REGISTRY,
+    ClosedEvent,
+    ErrorEvent,
+    ServerMessageType,
+)
+from .options import ConnectOptions
+from .transport import Transport
+
+_log = logging.getLogger(__name__)
+
+Handler = typing.Callable[[typing.Any], typing.Union[None, typing.Awaitable[None]]]
+WildcardHandler = typing.Callable[
+    [ServerMessageType, typing.Any], typing.Union[None, typing.Awaitable[None]]
+]
+
+
+class LiveTranscriptionSession:
+    """One live transcription connection.
+
+    Construct via :func:`connect` or the resource client on ``CambAI``;
+    direct construction is supported but the factory wires the transport
+    and handles URL building.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: Transport,
+        url: str,
+        headers: typing.Dict[str, str],
+    ) -> None:
+        self._transport = transport
+        self._url = url
+        self._headers = headers
+        self._handlers: typing.Dict[ServerMessageType, typing.List[Handler]] = {}
+        self._wildcard_handlers: typing.List[WildcardHandler] = []
+        self._reader_task: typing.Optional[asyncio.Task[None]] = None
+        self._closed = asyncio.Event()
+        self._ready = asyncio.Event()
+        self._send_lock = asyncio.Lock()
+        self._is_closing = False
+
+    # ---------------------------- lifecycle ----------------------------
+
+    async def __aenter__(self) -> "LiveTranscriptionSession":
+        await self._open()
+        return self
+
+    async def __aexit__(self, *exc: typing.Any) -> None:
+        await self.close()
+
+    async def _open(self) -> None:
+        await self._transport.connect(self._url, self._headers)
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+    @property
+    def is_ready(self) -> bool:
+        return self._ready.is_set()
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed.is_set()
+
+    async def wait_until_ready(self, timeout: typing.Optional[float] = None) -> None:
+        await asyncio.wait_for(self._ready.wait(), timeout=timeout)
+
+    async def run_until_closed(self) -> None:
+        await self._closed.wait()
+
+    # --------------------------- subscription --------------------------
+
+    def on(
+        self,
+        event_type: ServerMessageType,
+        handler: typing.Optional[Handler] = None,
+    ) -> typing.Any:
+        """Register a handler for ``event_type``.
+
+        Usable as either a direct call (``session.on(t, fn)``) or as a
+        decorator (``@session.on(t)``).
+        """
+
+        def _register(fn: Handler) -> Handler:
+            self._handlers.setdefault(event_type, []).append(fn)
+            return fn
+
+        if handler is None:
+            return _register
+        return _register(handler)
+
+    def off(self, event_type: ServerMessageType, handler: Handler) -> None:
+        if event_type in self._handlers:
+            try:
+                self._handlers[event_type].remove(handler)
+            except ValueError:
+                pass
+
+    def on_any(self, handler: WildcardHandler) -> WildcardHandler:
+        """Receive every event (including ones added in future releases)."""
+        self._wildcard_handlers.append(handler)
+        return handler
+
+    # ----------------------------- sending -----------------------------
+
+    async def send_audio(self, chunk: bytes) -> None:
+        async with self._send_lock:
+            await self._transport.send_bytes(chunk)
+
+    async def keep_alive(self) -> None:
+        async with self._send_lock:
+            await self._transport.send_text(json.dumps({"type": "KeepAlive"}))
+
+    async def stream_audio(self, source: AudioSource) -> None:
+        """Pump ``source`` chunks into the session until it is exhausted."""
+        try:
+            async for chunk in source:
+                if self._closed.is_set():
+                    break
+                await self.send_audio(chunk)
+        finally:
+            await source.close()
+
+    async def close(self) -> None:
+        if self._is_closing or self._closed.is_set():
+            return
+        self._is_closing = True
+        try:
+            await self._transport.send_text(json.dumps({"type": "CloseStream"}))
+        except Exception:  # transport may already be torn down
+            _log.debug("CloseStream send failed; closing transport directly", exc_info=True)
+        await self._transport.close(code=1000)
+        if self._reader_task is not None:
+            try:
+                await asyncio.wait_for(self._reader_task, timeout=5.0)
+            except asyncio.TimeoutError:
+                self._reader_task.cancel()
+
+    # ----------------------------- internals ---------------------------
+
+    async def _read_loop(self) -> None:
+        try:
+            async for frame in self._transport:
+                if isinstance(frame, (bytes, bytearray)):
+                    # Server does not send binary frames today; ignore.
+                    continue
+                try:
+                    data = json.loads(frame)
+                except json.JSONDecodeError:
+                    _log.warning("Discarding non-JSON server frame: %r", frame)
+                    continue
+                await self._dispatch(data)
+        finally:
+            await self._emit_close()
+
+    async def _dispatch(self, raw: typing.Dict[str, typing.Any]) -> None:
+        wire_type = raw.get("type")
+        try:
+            event_type = ServerMessageType(wire_type)
+        except ValueError:
+            # Forward-compat: unknown type still reaches on_any handlers.
+            await self._fan_out_wildcard(wire_type, raw)
+            return
+
+        model = PARSER_REGISTRY.get(event_type)
+        payload: typing.Any
+        if model is None:
+            payload = raw
+        else:
+            try:
+                # ErrorEvent gets the raw frame attached for diagnostics.
+                payload_fields = dict(raw)
+                payload_fields.pop("type", None)
+                if event_type is ServerMessageType.ERROR:
+                    payload_fields["raw"] = raw
+                payload = model.model_validate(payload_fields)
+            except pydantic.ValidationError as exc:
+                raise LiveTranscriptionProtocolError(
+                    f"Could not parse {event_type.value} frame: {exc}"
+                ) from exc
+
+        if event_type is ServerMessageType.READY:
+            self._ready.set()
+
+        await self._fan_out(event_type, payload)
+        await self._fan_out_wildcard(event_type, payload)
+
+    async def _emit_close(self) -> None:
+        if self._closed.is_set():
+            return
+        code = self._transport.close_code or 1000
+        reason = self._transport.close_reason or ""
+        payload = ClosedEvent(code=code, reason=reason)
+        await self._fan_out(ServerMessageType.CLOSED, payload)
+        await self._fan_out_wildcard(ServerMessageType.CLOSED, payload)
+        self._closed.set()
+
+    async def _fan_out(self, event_type: ServerMessageType, payload: typing.Any) -> None:
+        for handler in list(self._handlers.get(event_type, [])):
+            await self._safe_call(handler, payload)
+
+    async def _fan_out_wildcard(
+        self,
+        event_type: typing.Union[ServerMessageType, str, None],
+        payload: typing.Any,
+    ) -> None:
+        for handler in list(self._wildcard_handlers):
+            await self._safe_call(handler, event_type, payload)
+
+    async def _safe_call(self, handler: typing.Callable[..., typing.Any], *args: typing.Any) -> None:
+        try:
+            result = handler(*args)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            _log.exception("Handler raised: %s", exc)
+            # Surface to ErrorEvent subscribers so applications can react.
+            err = ErrorEvent(
+                code="handler_exception",
+                message=str(exc),
+                raw={"handler": getattr(handler, "__qualname__", repr(handler))},
+            )
+            for fn in list(self._handlers.get(ServerMessageType.ERROR, [])):
+                if fn is handler:
+                    continue  # avoid infinite recursion
+                try:
+                    res = fn(err)
+                    if inspect.isawaitable(res):
+                        await res
+                except Exception:
+                    _log.exception("Error-handler also raised; dropping")
+
+
+def _build_url(base_url: str, options: ConnectOptions) -> str:
+    """Convert the SDK's HTTP base URL into the live transcription WSS URL."""
+    from urllib.parse import urlencode
+
+    base = base_url.rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://"):]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://"):]
+    query = urlencode(options.to_query())
+    return f"{base}/transcription/listen?{query}"
+
+
+async def connect(
+    api_key: str,
+    *,
+    base_url: str = "https://client.camb.ai/apis",
+    transport: typing.Optional[Transport] = None,
+    extra_headers: typing.Optional[typing.Dict[str, str]] = None,
+    **options: typing.Any,
+) -> LiveTranscriptionSession:
+    """Open a live transcription session.
+
+    For most users the convenience accessor on ``CambAI`` is preferred:
+
+    >>> async with client.live_transcription.connect() as session:
+    ...     ...
+
+    Parameters mirror :class:`ConnectOptions` (``model``, ``language``,
+    ``encoding``, ``sample_rate``, ``channels``).
+    """
+    from .transport import WebsocketsTransport
+
+    opts = ConnectOptions(**options)
+    headers = {"x-api-key": api_key, **(extra_headers or {})}
+    url = _build_url(base_url, opts)
+    tport = transport if transport is not None else WebsocketsTransport()
+    session = LiveTranscriptionSession(transport=tport, url=url, headers=headers)
+    await session._open()
+    return session

--- a/camb/live_transcription/session.py
+++ b/camb/live_transcription/session.py
@@ -205,6 +205,10 @@ class LiveTranscriptionSession:
         code = self._transport.close_code or 1000
         reason = self._transport.close_reason or ""
         payload = ClosedEvent(code=code, reason=reason)
+        # Unblock anyone awaiting Ready: if we close without ever becoming
+        # ready, set the event so callers fail fast rather than hanging.
+        if not self._ready.is_set():
+            self._ready.set()
         await self._fan_out(ServerMessageType.CLOSED, payload)
         await self._fan_out_wildcard(ServerMessageType.CLOSED, payload)
         self._closed.set()

--- a/camb/live_transcription/session.py
+++ b/camb/live_transcription/session.py
@@ -65,6 +65,14 @@ class LiveTranscriptionSession:
         await self.close()
 
     async def _open(self) -> None:
+        # Idempotent: the resource client's connect() already opens the
+        # session before handing it back, and users typically wrap the
+        # returned session in `async with session:` for cleanup. Re-running
+        # _open here would spawn a second reader task on the same socket,
+        # causing every event to fan out twice and races to wedge the
+        # consumer iterator after a few frames.
+        if self._reader_task is not None:
+            return
         await self._transport.connect(self._url, self._headers)
         self._reader_task = asyncio.create_task(self._read_loop())
 

--- a/camb/live_transcription/transport.py
+++ b/camb/live_transcription/transport.py
@@ -1,0 +1,97 @@
+"""WebSocket transport abstraction.
+
+The session does not import ``websockets`` directly; it talks to
+:class:`Transport`. Swapping transports (for tests, mocks, alternative
+libraries) is therefore a one-line change at construction.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from .errors import LiveTranscriptionConnectError
+
+
+class Transport(typing.Protocol):
+    """Minimum surface a WebSocket implementation must expose."""
+
+    async def connect(self, url: str, headers: typing.Dict[str, str]) -> None: ...
+
+    async def send_bytes(self, data: bytes) -> None: ...
+
+    async def send_text(self, data: str) -> None: ...
+
+    def __aiter__(self) -> typing.AsyncIterator[typing.Union[str, bytes]]: ...
+
+    async def close(self, code: int = 1000) -> None: ...
+
+    @property
+    def close_code(self) -> typing.Optional[int]: ...
+
+    @property
+    def close_reason(self) -> typing.Optional[str]: ...
+
+
+class WebsocketsTransport:
+    """Default :class:`Transport` backed by the ``websockets`` library."""
+
+    def __init__(self) -> None:
+        self._ws: typing.Any = None
+        self._close_code: typing.Optional[int] = None
+        self._close_reason: typing.Optional[str] = None
+
+    async def connect(self, url: str, headers: typing.Dict[str, str]) -> None:
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover
+            raise LiveTranscriptionConnectError(
+                "The 'websockets' package is required for live transcription."
+            ) from exc
+
+        try:
+            # websockets >=12 prefers ``additional_headers``; older releases use
+            # ``extra_headers``. Try the modern kwarg first and fall back.
+            try:
+                self._ws = await websockets.connect(url, additional_headers=headers)
+            except TypeError:
+                self._ws = await websockets.connect(url, extra_headers=headers)
+        except Exception as exc:
+            raise LiveTranscriptionConnectError(str(exc)) from exc
+
+    async def send_bytes(self, data: bytes) -> None:
+        await self._ws.send(data)
+
+    async def send_text(self, data: str) -> None:
+        await self._ws.send(data)
+
+    def __aiter__(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        return self._iter()
+
+    async def _iter(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        try:
+            async for frame in self._ws:
+                yield frame
+        except Exception as exc:
+            try:
+                import websockets.exceptions as _ws_exc
+
+                if isinstance(exc, _ws_exc.ConnectionClosed):
+                    self._close_code = exc.code
+                    self._close_reason = exc.reason or ""
+                    return
+            except ImportError:  # pragma: no cover
+                pass
+            raise
+
+    async def close(self, code: int = 1000) -> None:
+        if self._ws is not None:
+            await self._ws.close(code=code)
+            self._close_code = code
+
+    @property
+    def close_code(self) -> typing.Optional[int]:
+        return self._close_code
+
+    @property
+    def close_reason(self) -> typing.Optional[str]:
+        return self._close_reason

--- a/examples/live_transcription_file.py
+++ b/examples/live_transcription_file.py
@@ -1,0 +1,63 @@
+"""Stream a local WAV file to the CAMB live transcription WebSocket.
+
+Useful when you cannot capture audio (CI, server, no sox/portaudio) but
+still want to exercise the live transcription pipeline end to end. The
+file is paced at real time so the server sees arrival patterns
+equivalent to a live capture.
+
+Run with:
+
+    export CAMB_API_KEY=...
+    python examples/live_transcription_file.py path/to/audio.wav
+"""
+
+import asyncio
+import os
+import sys
+
+from camb.client import CambAI
+from camb.live_transcription import FileAudioSource, ServerMessageType
+
+
+async def main(path: str) -> None:
+    import wave
+
+    with wave.open(path, "rb") as wf:
+        sample_rate = wf.getframerate()
+        channels = wf.getnchannels()
+
+    client = CambAI(api_key=os.environ["CAMB_API_KEY"])
+    session = await client.live_transcription.connect(
+        model="boli-v5",
+        language="en-us",
+        encoding="linear16",
+        sample_rate=sample_rate,
+        channels=channels,
+    )
+
+    @session.on(ServerMessageType.READY)
+    def _(_):
+        print(f"Streaming {path} at {sample_rate} Hz...")
+
+    @session.on(ServerMessageType.RESULTS)
+    def _(msg):
+        print(f"\r{msg.transcript}", end="", flush=True)
+
+    @session.on(ServerMessageType.ERROR)
+    def _(err):
+        print(f"\n[error] {err.code}: {err.message}")
+
+    @session.on(ServerMessageType.CLOSED)
+    def _(info):
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+
+    async with session:
+        await session.wait_until_ready(timeout=10)
+        await session.stream_audio(FileAudioSource(path, chunk_ms=100, real_time=True))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: python examples/live_transcription_file.py PATH_TO_WAV", file=sys.stderr)
+        sys.exit(2)
+    asyncio.run(main(sys.argv[1]))

--- a/examples/live_transcription_microphone.py
+++ b/examples/live_transcription_microphone.py
@@ -2,7 +2,7 @@
 
 Run with:
 
-    pip install "camb-sdk[microphone]"
+    pip install camb-sdk
     CAMB_API_KEY=... python examples/live_transcription_microphone.py
 """
 

--- a/examples/live_transcription_microphone.py
+++ b/examples/live_transcription_microphone.py
@@ -1,0 +1,52 @@
+"""Stream microphone audio to the CAMB live transcription WebSocket.
+
+Run with:
+
+    pip install "camb-sdk[microphone]"
+    CAMB_API_KEY=... python examples/live_transcription_microphone.py
+"""
+
+import asyncio
+import os
+
+from camb.client import CambAI
+from camb.live_transcription import Microphone, ServerMessageType
+
+
+async def main() -> None:
+    client = CambAI(api_key=os.environ["CAMB_API_KEY"])
+
+    session = await client.live_transcription.connect(
+        model="boli-v5",
+        language="en-us",
+        sample_rate=16000,
+    )
+
+    @session.on(ServerMessageType.READY)
+    def _ready(_):
+        print("Session ready. Speak into the microphone; Ctrl-C to stop.")
+
+    @session.on(ServerMessageType.RESULTS)
+    def _results(msg):
+        # Cumulative transcript: replace the previous line in the UI rather
+        # than concatenating successive Results events.
+        print(f"\r{msg.transcript}", end="", flush=True)
+
+    @session.on(ServerMessageType.ERROR)
+    def _error(err):
+        print(f"\nServer error: {err.code} {err.message}")
+
+    @session.on(ServerMessageType.CLOSED)
+    def _closed(info):
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+
+    async with session:
+        mic = Microphone(sample_rate=16000, chunk_size=1600)
+        try:
+            await session.stream_audio(mic)
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,7 @@ dependencies = [
   "websocket-client>=1.6.0"
 ]
 
+[project.optional-dependencies]
+microphone = ["sounddevice>=0.4.6"]
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,8 @@ dependencies = [
   "pydantic>=1.10.0",
   "typing_extensions>=4.0.0",
   "websockets>=11.0.3",
-  "websocket-client>=1.6.0"
+  "websocket-client>=1.6.0",
+  "sounddevice>=0.4.6"
 ]
-
-[project.optional-dependencies]
-microphone = ["sounddevice>=0.4.6"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "camb-sdk"
-version = "1.5.11"
+version = "1.5.12"
 readme = "README.md"
 description = "The official Python SDK for the Camb.ai API"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic>=1.10.0
 typing_extensions>=4.0.0
 websockets>=11.0.3
 websocket-client>=1.6.0
+sounddevice>=0.4.6

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="camb-sdk",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version="1.5.11",
+    version="1.5.12",
     packages=find_packages(where="."),
     package_dir={"": "."},
     install_requires=[
@@ -17,6 +17,7 @@ setup(
         "typing_extensions>=4.0.0",
         "websockets>=11.0.3",
         "websocket-client>=1.6.0",
+        "sounddevice>=0.4.6",
     ],
     package_data={"camb": ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
## Summary

Adds `camb.live_transcription` — a typed, async WebSocket client wrapping the [`/apis/transcription/listen`](https://docs.camb.ai/api-reference/websockets/listen) endpoint. End-to-end verified against the dev backend.

### What ships

```python
from camb.client import CambAI
from camb.live_transcription import Microphone, ServerMessageType

client = CambAI(api_key=...)
session = await client.live_transcription.connect(
    model="boli-v5",
    language="en-us",
    sample_rate=16000,
)

@session.on(ServerMessageType.RESULTS)
def _(msg):
    print(msg.transcript)   # cumulative interim — replace, don't concat

async with session:
    await session.stream_audio(Microphone(sample_rate=16000, chunk_size=1600))
```

- **Typed events** — `Ready`, `Results`, `Final` (reserved), `Error`, `Closed`. All defined via a single `ServerMessageType` enum + Pydantic models + `PARSER_REGISTRY`. Adding a new event = three edits in one file.
- **Microphone helper** — `sounddevice`-based capture, now a regular dependency.
- **File source** — `FileAudioSource` paces a WAV at real-time for tests / CI.
- **Wildcard handler** — `session.on_any` catches event types the SDK hasn't been updated for yet, so apps stay forward-compatible.
- **Custom transport** — pluggable `Transport` protocol so tests can inject mocks; default uses `websockets`.
- **Error hierarchy** — `LiveTranscriptionError` + `…ConnectError` / `…ProtocolError` subclasses.

### Bugs found and fixed during integration testing

1. **WebSocket race** — server's `Ready` was being dropped when the handshake completed before the read loop attached.
2. **`waitUntilReady` hang on auth failure** — close before Ready left awaiters hanging; now wakes the event.
3. **Double-open via `async with`** — `connect()` already opens the session, so `async with session:` re-ran `_open()`, spawning a second reader task. Symptom: every event fired twice and the session wedged after a few frames. `_open()` is now idempotent.

### Files

```
camb/live_transcription/
├── __init__.py          # public exports
├── client.py            # LiveTranscriptionClient (camb.live_transcription)
├── session.py           # LiveTranscriptionSession + module-level connect()
├── transport.py         # Transport protocol + WebsocketsTransport
├── events.py            # ServerMessageType + Pydantic models + PARSER_REGISTRY
├── options.py           # Encoding + ConnectOptions
├── audio_source.py      # AudioSource protocol + FileAudioSource
├── microphone.py        # Microphone (sounddevice)
└── errors.py            # LiveTranscriptionError hierarchy

examples/
├── live_transcription_microphone.py   # mic → session
└── live_transcription_file.py         # WAV → session at real-time pace
```

### Test plan

- [x] Smoke test of imports + model parsing in `py3125` conda env.
- [x] End-to-end: stream WAV → dev endpoint → received `Ready` + 9 cumulative `Results` + clean `Closed(1000)`. Final transcript: `" Welcome to our service. We're glad to have"`.
- [x] Negative path: invalid key → `Closed(1008, "Invalid/Expired API Key")` surfaced cleanly, no hang.
- [x] Post-fix verification: `Ready` fires exactly once, no late wedge under `async with`.
- [ ] Reviewer: run `examples/live_transcription_file.py public_docs/audio/demo-accent-en-us.wav` against staging once the route is healthy.

### Related

- Docs PR: Camb-ai/public_docs#117
- Companion TS SDK PR: Camb-ai/cambai-typescript-sdk (filed in this same batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)