### PR TITLE
Label interim frames, commit finals in live transcription examples

### DIFF
--- a/camb/live_transcription/events.py
+++ b/camb/live_transcription/events.py
@@ -63,10 +63,14 @@ class Metadata(_LiveModel):
 
 
 class ResultsEvent(_LiveModel):
-    """Cumulative interim transcript for the current utterance.
+    """Cumulative transcript for the current utterance.
 
-    Replace your UI state with the latest ``transcript`` rather than
-    concatenating; each event carries the full transcript so far.
+    Each event carries the full transcript so far, so replace your
+    in-progress UI state with ``transcript`` rather than concatenating.
+    ``is_final`` is ``False`` for interim refinements and ``True`` on the
+    frame that finalizes the utterance; after a final the next event
+    begins a new utterance from scratch, so commit the text when
+    ``is_final`` is ``True`` to keep finished utterances.
     """
 
     is_final: bool = False

--- a/examples/live_transcription_file.py
+++ b/examples/live_transcription_file.py
@@ -41,15 +41,25 @@ async def main(path: str) -> None:
 
     @session.on(ServerMessageType.RESULTS)
     def _(msg):
-        print(msg.transcript)
+        text = msg.transcript.strip()
+        if not text:
+            return
+        # Interim frames refine the current utterance; print them as they
+        # arrive. On is_final the utterance is done — commit it on its own
+        # line so the next utterance starts fresh instead of overwriting it.
+        if not msg.is_final:
+            print(f"[Interim] {text}\n", end="", flush=True)
+        else:
+            print(f"\r\033[K{text}\n", end="", flush=True)
 
     @session.on(ServerMessageType.ERROR)
     def _(err):
-        print(f"[error] {err.code}: {err.message}")
+        # Leading newline: an interim line may be in progress (no newline yet).
+        print(f"\n[error] {err.code}: {err.message}")
 
     @session.on(ServerMessageType.CLOSED)
     def _(info):
-        print(f"Closed: code={info.code} reason={info.reason!r}")
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
 
     async with session:
         await session.wait_until_ready(timeout=10)

--- a/examples/live_transcription_file.py
+++ b/examples/live_transcription_file.py
@@ -41,15 +41,15 @@ async def main(path: str) -> None:
 
     @session.on(ServerMessageType.RESULTS)
     def _(msg):
-        print(f"\r{msg.transcript}", end="", flush=True)
+        print(msg.transcript)
 
     @session.on(ServerMessageType.ERROR)
     def _(err):
-        print(f"\n[error] {err.code}: {err.message}")
+        print(f"[error] {err.code}: {err.message}")
 
     @session.on(ServerMessageType.CLOSED)
     def _(info):
-        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+        print(f"Closed: code={info.code} reason={info.reason!r}")
 
     async with session:
         await session.wait_until_ready(timeout=10)

--- a/examples/live_transcription_microphone.py
+++ b/examples/live_transcription_microphone.py
@@ -28,15 +28,22 @@ async def main() -> None:
 
     @session.on(ServerMessageType.RESULTS)
     def _results(msg):
-        print(msg.transcript)
+        text = msg.transcript.strip()
+        if not text:
+            return
+        if not msg.is_final:
+            print(f"[Interim] {text}\n", end="", flush=True)
+        else:
+            print(f"\r\033[K{text}\n", end="", flush=True)
 
     @session.on(ServerMessageType.ERROR)
     def _error(err):
-        print(f"Server error: {err.code} {err.message}")
+        # Leading newline: an interim line may be in progress (no newline yet).
+        print(f"\nServer error: {err.code} {err.message}")
 
     @session.on(ServerMessageType.CLOSED)
     def _closed(info):
-        print(f"Closed: code={info.code} reason={info.reason!r}")
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
 
     async with session:
         mic = Microphone(sample_rate=16000, chunk_size=1600)

--- a/examples/live_transcription_microphone.py
+++ b/examples/live_transcription_microphone.py
@@ -28,17 +28,15 @@ async def main() -> None:
 
     @session.on(ServerMessageType.RESULTS)
     def _results(msg):
-        # Cumulative transcript: replace the previous line in the UI rather
-        # than concatenating successive Results events.
-        print(f"\r{msg.transcript}", end="", flush=True)
+        print(msg.transcript)
 
     @session.on(ServerMessageType.ERROR)
     def _error(err):
-        print(f"\nServer error: {err.code} {err.message}")
+        print(f"Server error: {err.code} {err.message}")
 
     @session.on(ServerMessageType.CLOSED)
     def _closed(info):
-        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+        print(f"Closed: code={info.code} reason={info.reason!r}")
 
     async with session:
         mic = Microphone(sample_rate=16000, chunk_size=1600)


### PR DESCRIPTION
## Summary
The realtime backend ships a cumulative transcript per utterance and resets it on each new utterance (`is_final` flips `true` on the finalizing frame). Printing every `Results` plainly floods a line per interim, and the older `\r` overwrite loses prior utterances after a pause.

This makes the examples `is_final`-aware:
- interim frames print as `[Interim] {text}` lines;
- the finalized utterance commits on its own line (`\r\033[K{text}\n`), so a new utterance after a pause no longer overwrites the previous one.

Also documents `is_final` / commit-on-final on the `ResultsEvent` docstring.

## Test plan
- [ ] `python examples/live_transcription_microphone.py` — speak, pause, speak again: each finished utterance lands on its own line; interims show as `[Interim] …`
- [ ] `python examples/live_transcription_file.py sample.wav` — same, file-paced

🤖 Generated with [Claude Code](https://claude.com/claude-code)