### PR TITLE
feat(realtime): add realtime speech translation WebSocket client

### DIFF
--- a/camb/client.py
+++ b/camb/client.py
@@ -151,6 +151,7 @@ class CambAI:
         self._project_setup: typing.Optional[ProjectSetupClient] = None
         self._deprecated_streaming: typing.Optional[DeprecatedStreamingClient] = None
         self._live_transcription: typing.Optional[typing.Any] = None
+        self._realtime: typing.Optional[typing.Any] = None
 
     @property
     def with_raw_response(self) -> RawCambApi:
@@ -381,6 +382,14 @@ class CambAI:
             self._live_transcription = LiveTranscriptionClient(client_wrapper=self._client_wrapper)
         return self._live_transcription
 
+    @property
+    def realtime(self):
+        if self._realtime is None:
+            from .realtime.client import RealtimeClient  # noqa: E402
+
+            self._realtime = RealtimeClient(client_wrapper=self._client_wrapper)
+        return self._realtime
+
 
 class AsyncCambAI:
     """
@@ -473,6 +482,7 @@ class AsyncCambAI:
         self._project_setup: typing.Optional[AsyncProjectSetupClient] = None
         self._deprecated_streaming: typing.Optional[AsyncDeprecatedStreamingClient] = None
         self._live_transcription: typing.Optional[typing.Any] = None
+        self._realtime: typing.Optional[typing.Any] = None
 
     @property
     def with_raw_response(self) -> AsyncRawCambApi:
@@ -728,6 +738,14 @@ class AsyncCambAI:
             # wrapper carries the same api_key/base_url state we need.
             self._live_transcription = LiveTranscriptionClient(client_wrapper=self._client_wrapper)
         return self._live_transcription
+
+    @property
+    def realtime(self):
+        if self._realtime is None:
+            from .realtime.client import RealtimeClient  # noqa: E402
+
+            self._realtime = RealtimeClient(client_wrapper=self._client_wrapper)
+        return self._realtime
 
 
 def _get_base_url(*, base_url: typing.Optional[str] = None, environment: CambApiEnvironment) -> str:

--- a/camb/realtime/__init__.py
+++ b/camb/realtime/__init__.py
@@ -1,0 +1,89 @@
+"""Realtime speech-to-speech translation WebSocket client.
+
+This package wraps the ``/v1/realtime`` WebSocket endpoint documented in the
+AsyncAPI spec under ``realtime.camb.ai``.
+
+Quick start::
+
+    import asyncio
+    from camb import CambAI
+    from camb.realtime import ServerEventType
+    from camb.live_transcription import Microphone
+
+    async def main():
+        client = CambAI(api_key="...")
+        session = await client.realtime.connect(
+            source_language="en-US",
+            target_language="de-DE",
+        )
+
+        @session.on(ServerEventType.SESSION_STARTING)
+        def _(_):
+            print("Booting pipeline...")
+
+        @session.on(ServerEventType.AUDIO_DELTA)
+        def _(event):
+            play_audio(event.data)
+
+        @session.on(ServerEventType.TEXT_DONE)
+        def _(event):
+            print("Translation:", event.text)
+
+        async with session:
+            await session.wait_until_ready()
+            mic = Microphone(sample_rate=24000)
+            await session.stream_audio(mic)
+
+    asyncio.run(main())
+"""
+
+from .client import RealtimeClient
+from .errors import (
+    RealtimeConnectError,
+    RealtimeError,
+    RealtimeProtocolError,
+)
+from .events import (
+    AudioDeltaEvent,
+    AudioDoneEvent,
+    ClosedEvent,
+    ErrorEvent,
+    PARSER_REGISTRY,
+    ServerEventType,
+    SessionConfig,
+    SessionCreatedEvent,
+    SessionInfo,
+    SessionStartingEvent,
+    SessionUpdatedEvent,
+    TextDeltaEvent,
+    TextDoneEvent,
+    TranscriptCompletedEvent,
+)
+from .options import ConnectOptions, OutputModality, RealtimeModel
+from .session import RealtimeSession, connect
+
+__all__ = [
+    "AudioDeltaEvent",
+    "AudioDoneEvent",
+    "ClosedEvent",
+    "ConnectOptions",
+    "ErrorEvent",
+    "OutputModality",
+    "PARSER_REGISTRY",
+    "RealtimeClient",
+    "RealtimeConnectError",
+    "RealtimeError",
+    "RealtimeModel",
+    "RealtimeProtocolError",
+    "RealtimeSession",
+    "ServerEventType",
+    "SessionConfig",
+    "SessionCreatedEvent",
+    "SessionInfo",
+    "SessionStartingEvent",
+    "SessionUpdatedEvent",
+    "TextDeltaEvent",
+    "TextDoneEvent",
+    "TranscriptCompletedEvent",
+    "connect",
+]

--- a/camb/realtime/client.py
+++ b/camb/realtime/client.py
@@ -1,0 +1,81 @@
+"""Resource client exposed as :attr:`CambAI.realtime`."""
+
+from __future__ import annotations
+
+import typing
+
+from ..core.client_wrapper import SyncClientWrapper
+from .errors import RealtimeConnectError
+from .session import (
+    DEFAULT_REALTIME_BASE_URL,
+    RealtimeSession,
+    connect as _connect,
+)
+from .transport import Transport
+
+
+class RealtimeClient:
+    """Entry point for the realtime speech translation WebSocket.
+
+    Usage::
+
+        from camb import CambAI
+        from camb.realtime import ServerEventType
+
+        client = CambAI(api_key="...")
+        session = await client.realtime.connect(
+            source_language="en-US",
+            target_language="de-DE",
+        )
+
+        @session.on(ServerEventType.AUDIO_DELTA)
+        def on_audio(event):
+            play(event.data)
+
+        async with session:
+            await session.wait_until_ready()
+            async for chunk in microphone:
+                await session.send_audio(chunk)
+    """
+
+    def __init__(
+        self,
+        *,
+        client_wrapper: SyncClientWrapper,
+        realtime_base_url: typing.Optional[str] = None,
+    ) -> None:
+        self._client_wrapper = client_wrapper
+
+    async def connect(
+        self,
+        *,
+        transport: typing.Optional[Transport] = None,
+        **options: typing.Any,
+    ) -> RealtimeSession:
+        """Open a realtime translation session.
+
+        Keyword arguments are forwarded to
+        :class:`~camb.realtime.options.ConnectOptions`:
+
+        - ``source_language`` *(required)* — IETF BCP-47 tag, e.g. ``"en-US"``
+        - ``target_language`` *(required)* — IETF BCP-47 tag, e.g. ``"de-DE"``
+        - ``model`` — one of ``"lilac"`` (default), ``"violet"``, ``"iris"``, ``"orchid"``
+        - ``output_modalities`` — list of ``"text"`` and/or ``"audio"`` (default: both)
+
+        Returns an open :class:`~camb.realtime.session.RealtimeSession`.  The
+        session is not yet ready to accept audio; call
+        ``await session.wait_until_ready()`` (or register a
+        ``ServerEventType.SESSION_CREATED`` handler) before sending audio.
+        """
+        api_key = self._client_wrapper.api_key
+        if not api_key:
+            raise RealtimeConnectError(
+                "CambAI was constructed without an api_key; cannot open a realtime session."
+            )
+        return await _connect(
+            api_key=api_key,
+            base_url=DEFAULT_REALTIME_BASE_URL,
+            transport=transport,
+            extra_headers=self._client_wrapper.get_custom_headers(),
+            **options,
+        )

--- a/camb/realtime/errors.py
+++ b/camb/realtime/errors.py
@@ -1,0 +1,14 @@
+"""Exceptions raised by the realtime translation client."""
+
+
+class RealtimeError(Exception):
+    """Base class for every exception raised by ``camb.realtime``."""
+
+
+class RealtimeConnectError(RealtimeError):
+    """The WebSocket handshake failed, the server rejected the upgrade, or
+    the session did not become ready within the allowed timeout."""
+
+
+class RealtimeProtocolError(RealtimeError):
+    """The server sent a frame the client could not decode or validate."""

--- a/camb/realtime/events.py
+++ b/camb/realtime/events.py
@@ -1,0 +1,142 @@
+"""Typed server events emitted over the realtime WebSocket.
+
+Adding a new server event requires exactly three edits:
+
+1. Add a member to :class:`ServerEventType`.
+2. Define a payload model below.
+3. Register the pair in :data:`PARSER_REGISTRY` (or add manual handling in
+   ``RealtimeSession._dispatch`` for events that need transformation, such as
+   ``AUDIO_DELTA`` and ``ERROR``).
+"""
+
+from __future__ import annotations
+
+import enum
+import typing
+
+import pydantic
+
+
+class ServerEventType(str, enum.Enum):
+    """Stable identifiers for every event the client may dispatch to handlers."""
+
+    SESSION_STARTING = "session.starting"
+    SESSION_CREATED = "session.created"
+    SESSION_UPDATED = "session.updated"
+    TRANSCRIPT_COMPLETED = "conversation.item.input_audio_transcription.completed"
+    TEXT_DELTA = "response.text.delta"
+    TEXT_DONE = "response.text.done"
+    # AUDIO_DELTA is handled manually in _dispatch (binary frame or base64 JSON).
+    AUDIO_DELTA = "response.audio.delta"
+    AUDIO_DONE = "response.audio.done"
+    ERROR = "error"
+    # Synthetic — emitted by the SDK when the transport closes, never sent by server.
+    CLOSED = "Closed"
+
+
+class _RealtimeModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="allow")
+
+
+class SessionStartingEvent(_RealtimeModel):
+    """Emitted early during pipeline boot so clients can show a loading indicator.
+
+    No payload beyond the event type. The session is not yet ready to accept
+    audio; wait for :class:`SessionCreatedEvent` (or ``session.wait_until_ready()``)
+    before sending audio.
+    """
+
+
+class SessionInfo(_RealtimeModel):
+    id: str
+    model: str
+    source_language: str
+    target_language: str
+    output_modalities: typing.List[str] = pydantic.Field(default_factory=list)
+
+
+class SessionConfig(_RealtimeModel):
+    model: typing.Optional[str] = None
+    source_language: str
+    target_language: str
+    output_modalities: typing.List[str] = pydantic.Field(default_factory=list)
+
+
+class SessionCreatedEvent(_RealtimeModel):
+    """The session has been authorised and the pipeline is ready to accept audio."""
+
+    session: SessionInfo
+
+
+class SessionUpdatedEvent(_RealtimeModel):
+    """Echo of the session configuration, sent immediately after ``session.created``."""
+
+    session: SessionConfig
+
+
+class TranscriptCompletedEvent(_RealtimeModel):
+    """Final transcript for the most recent user utterance."""
+
+    transcript: str
+
+
+class TextDeltaEvent(_RealtimeModel):
+    """Incremental translated text.
+
+    Deltas are additive within one response; the accumulated text resets
+    after the corresponding :class:`TextDoneEvent`.
+    """
+
+    delta: str
+
+
+class TextDoneEvent(_RealtimeModel):
+    """Complete translated text for the current response."""
+
+    text: str
+
+
+class AudioDeltaEvent(_RealtimeModel):
+    """Synthesized output audio chunk.
+
+    ``data`` always contains raw PCM bytes regardless of whether the server
+    delivered them as a binary WebSocket frame or a base64-encoded JSON delta.
+    This normalisation happens inside the session dispatcher before the event
+    reaches handlers.
+    """
+
+    data: bytes
+
+
+class AudioDoneEvent(_RealtimeModel):
+    """The current synthesized audio response is complete."""
+
+
+class ErrorEvent(_RealtimeModel):
+    """Structured error from the server, or a handler exception surfaced by the SDK."""
+
+    message: str
+    raw: typing.Dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class ClosedEvent(_RealtimeModel):
+    """Synthetic event emitted by the SDK when the transport closes."""
+
+    code: int
+    reason: str = ""
+
+
+# AUDIO_DELTA and ERROR are intentionally absent — they need transformation
+# (base64 decode and nested-object flattening respectively) before the model
+# can be constructed, so RealtimeSession._dispatch handles them manually.
+PARSER_REGISTRY: typing.Dict[ServerEventType, typing.Optional[typing.Type[_RealtimeModel]]] = {
+    ServerEventType.SESSION_STARTING: SessionStartingEvent,
+    ServerEventType.SESSION_CREATED: SessionCreatedEvent,
+    ServerEventType.SESSION_UPDATED: SessionUpdatedEvent,
+    ServerEventType.TRANSCRIPT_COMPLETED: TranscriptCompletedEvent,
+    ServerEventType.TEXT_DELTA: TextDeltaEvent,
+    ServerEventType.TEXT_DONE: TextDoneEvent,
+    ServerEventType.AUDIO_DONE: AudioDoneEvent,
+    ServerEventType.CLOSED: ClosedEvent,
+}
+"""Single source of truth mapping wire ``type`` strings to payload models."""

--- a/camb/realtime/options.py
+++ b/camb/realtime/options.py
@@ -1,0 +1,50 @@
+"""Connection options for the realtime WebSocket."""
+
+from __future__ import annotations
+
+import enum
+import typing
+
+import pydantic
+
+
+class RealtimeModel(str, enum.Enum):
+    LILAC = "lilac"
+    VIOLET = "violet"
+    IRIS = "iris"
+    ORCHID = "orchid"
+
+
+class OutputModality(str, enum.Enum):
+    TEXT = "text"
+    AUDIO = "audio"
+
+
+class ConnectOptions(pydantic.BaseModel):
+    """Options for a realtime translation session.
+
+    ``source_language`` and ``target_language`` are required; all other fields
+    have server-side defaults.
+
+    Language values use IETF BCP-47 tags (e.g. ``"en-US"``, ``"de-DE"``).
+    """
+
+    model: RealtimeModel = RealtimeModel.LILAC
+    source_language: str
+    target_language: str
+    output_modalities: typing.List[OutputModality] = pydantic.Field(
+        default_factory=lambda: [OutputModality.TEXT, OutputModality.AUDIO]
+    )
+
+    def to_query(self) -> typing.Dict[str, str]:
+        """Query-string parameters sent on the WebSocket upgrade URL."""
+        return {"model": self.model.value}
+
+    def to_session_payload(self) -> typing.Dict[str, typing.Any]:
+        """Body of the ``session.update`` message sent after the WS handshake."""
+        return {
+            "model": self.model.value,
+            "source_language": self.source_language,
+            "target_language": self.target_language,
+            "output_modalities": [m.value for m in self.output_modalities],
+        }

--- a/camb/realtime/session.py
+++ b/camb/realtime/session.py
@@ -1,0 +1,373 @@
+"""Realtime translation session — one open WebSocket and its event pump."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import inspect
+import json
+import logging
+import typing
+from urllib.parse import urlencode
+
+import pydantic
+
+from .errors import RealtimeConnectError, RealtimeProtocolError
+from .events import (
+    PARSER_REGISTRY,
+    AudioDeltaEvent,
+    ClosedEvent,
+    ErrorEvent,
+    ServerEventType,
+)
+from .options import ConnectOptions
+from .transport import Transport, WebsocketsTransport
+
+_log = logging.getLogger(__name__)
+
+SESSION_READY_TIMEOUT = 90.0
+DEFAULT_REALTIME_BASE_URL = "wss://realtime.camb.ai"
+_REALTIME_PATH = "/v1/realtime"
+
+Handler = typing.Callable[[typing.Any], typing.Union[None, typing.Awaitable[None]]]
+WildcardHandler = typing.Callable[
+    [ServerEventType, typing.Any], typing.Union[None, typing.Awaitable[None]]
+]
+
+
+class RealtimeSession:
+    """One realtime translation connection.
+
+    Construct via :func:`connect` or the resource client on ``CambAI``;
+    direct construction is supported but the factory wires the transport
+    and handles URL building.
+
+    Typical usage::
+
+        session = await client.realtime.connect(
+            source_language="en-US",
+            target_language="de-DE",
+        )
+
+        @session.on(ServerEventType.AUDIO_DELTA)
+        def on_audio(event):
+            play(event.data)
+
+        async with session:
+            await session.wait_until_ready()
+            async for chunk in microphone:
+                await session.send_audio(chunk)
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: Transport,
+        url: str,
+        headers: typing.Dict[str, str],
+        session_payload: typing.Dict[str, typing.Any],
+    ) -> None:
+        self._transport = transport
+        self._url = url
+        self._headers = headers
+        self._session_payload = session_payload
+        self._handlers: typing.Dict[ServerEventType, typing.List[Handler]] = {}
+        self._wildcard_handlers: typing.List[WildcardHandler] = []
+        self._reader_task: typing.Optional[asyncio.Task[None]] = None
+        self._closed = asyncio.Event()
+        self._ready = asyncio.Event()
+        self._send_lock = asyncio.Lock()
+        self._is_closing = False
+
+    # ---------------------------- lifecycle ----------------------------
+
+    async def __aenter__(self) -> "RealtimeSession":
+        await self._open()
+        return self
+
+    async def __aexit__(self, *exc: typing.Any) -> None:
+        await self.close()
+
+    async def _open(self) -> None:
+        # Idempotent: the factory's connect() already calls _open; wrapping the
+        # returned session in `async with session:` re-enters here and must not
+        # spawn a second reader task.
+        if self._reader_task is not None:
+            return
+        await self._transport.connect(self._url, self._headers)
+        await self._transport.send_text(json.dumps(self._session_payload))
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+    @property
+    def is_ready(self) -> bool:
+        """True once the server has sent ``session.created``."""
+        return self._ready.is_set()
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed.is_set()
+
+    async def wait_until_ready(
+        self, timeout: typing.Optional[float] = SESSION_READY_TIMEOUT
+    ) -> None:
+        """Block until the server confirms the session is active.
+
+        Non-iris models cold-boot for 30+ seconds; the server sends
+        ``session.starting`` (and WebSocket keepalive pings) during that window
+        to signal it is still working. Raises :class:`RealtimeConnectError` if
+        ``timeout`` elapses or the socket closes before ``session.created`` arrives.
+        """
+        try:
+            await asyncio.wait_for(self._ready.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise RealtimeConnectError(
+                f"Timed out waiting for session.created after {timeout}s"
+            )
+        if self._closed.is_set():
+            raise RealtimeConnectError(
+                "WebSocket closed before the session became ready"
+            )
+
+    async def run_until_closed(self) -> None:
+        """Suspend until the transport closes."""
+        await self._closed.wait()
+
+    # --------------------------- subscription --------------------------
+
+    def on(
+        self,
+        event_type: ServerEventType,
+        handler: typing.Optional[Handler] = None,
+    ) -> typing.Any:
+        """Register a handler for ``event_type``.
+
+        Usable as a direct call (``session.on(t, fn)``) or as a decorator
+        (``@session.on(t)``).
+        """
+
+        def _register(fn: Handler) -> Handler:
+            self._handlers.setdefault(event_type, []).append(fn)
+            return fn
+
+        if handler is None:
+            return _register
+        return _register(handler)
+
+    def off(self, event_type: ServerEventType, handler: Handler) -> None:
+        if event_type in self._handlers:
+            try:
+                self._handlers[event_type].remove(handler)
+            except ValueError:
+                pass
+
+    def on_any(self, handler: WildcardHandler) -> WildcardHandler:
+        """Receive every event, including types added in future server releases."""
+        self._wildcard_handlers.append(handler)
+        return handler
+
+    # ----------------------------- sending -----------------------------
+
+    async def send_audio(self, chunk: bytes) -> None:
+        """Send a raw PCM chunk to the server as a base64-encoded audio append."""
+        async with self._send_lock:
+            payload = json.dumps(
+                {
+                    "type": "input_audio_buffer.append",
+                    "audio": base64.b64encode(chunk).decode(),
+                }
+            )
+            await self._transport.send_text(payload)
+
+    async def stream_audio(self, source: typing.AsyncIterable[bytes]) -> None:
+        """Pump chunks from ``source`` into the session until it is exhausted.
+
+        If ``source`` has a ``close()`` coroutine it is called on exit.
+        """
+        try:
+            async for chunk in source:
+                if self._closed.is_set():
+                    break
+                await self.send_audio(chunk)
+        finally:
+            close_fn = getattr(source, "close", None)
+            if close_fn is not None:
+                await close_fn()
+
+    async def close(self) -> None:
+        if self._is_closing or self._closed.is_set():
+            return
+        self._is_closing = True
+        await self._transport.close(code=1000)
+        if self._reader_task is not None:
+            try:
+                await asyncio.wait_for(self._reader_task, timeout=5.0)
+            except asyncio.TimeoutError:
+                self._reader_task.cancel()
+
+    # ----------------------------- internals ---------------------------
+
+    async def _read_loop(self) -> None:
+        try:
+            async for frame in self._transport:
+                if isinstance(frame, (bytes, bytearray)):
+                    # Binary frame: raw PCM from the server (optimization path).
+                    event = AudioDeltaEvent(data=bytes(frame))
+                    await self._fan_out(ServerEventType.AUDIO_DELTA, event)
+                    await self._fan_out_wildcard(ServerEventType.AUDIO_DELTA, event)
+                    continue
+                try:
+                    data = json.loads(frame)
+                except json.JSONDecodeError:
+                    _log.warning("Discarding non-JSON server frame: %r", frame)
+                    continue
+                await self._dispatch(data)
+        finally:
+            await self._emit_close()
+
+    async def _dispatch(self, raw: typing.Dict[str, typing.Any]) -> None:
+        wire_type = raw.get("type")
+        try:
+            event_type = ServerEventType(wire_type)
+        except ValueError:
+            # Forward-compat: unknown type still reaches on_any handlers.
+            await self._fan_out_wildcard(wire_type, raw)
+            return
+
+        payload: typing.Any
+
+        if event_type is ServerEventType.AUDIO_DELTA:
+            # JSON audio delta: base64-decode the delta field into raw bytes.
+            try:
+                data = base64.b64decode(raw.get("delta", ""))
+            except Exception:
+                data = b""
+            payload = AudioDeltaEvent(data=data)
+
+        elif event_type is ServerEventType.ERROR:
+            # Wire format: {"type": "error", "error": {"message": "..."}}.
+            # Flatten the nested object for the handler model.
+            error_obj = raw.get("error", {})
+            payload = ErrorEvent(
+                message=error_obj.get("message", "Unknown error"),
+                raw=raw,
+            )
+
+        else:
+            model = PARSER_REGISTRY.get(event_type)
+            if model is None:
+                payload = raw
+            else:
+                fields = {k: v for k, v in raw.items() if k != "type"}
+                try:
+                    payload = model.model_validate(fields)
+                except pydantic.ValidationError as exc:
+                    raise RealtimeProtocolError(
+                        f"Could not parse {event_type.value} frame: {exc}"
+                    ) from exc
+
+        if event_type is ServerEventType.SESSION_CREATED and not self._ready.is_set():
+            self._ready.set()
+
+        await self._fan_out(event_type, payload)
+        await self._fan_out_wildcard(event_type, payload)
+
+    async def _emit_close(self) -> None:
+        if self._closed.is_set():
+            return
+        code = self._transport.close_code or 1000
+        reason = self._transport.close_reason or ""
+        payload = ClosedEvent(code=code, reason=reason)
+        # Unblock wait_until_ready so callers fail fast if the socket dies
+        # before the session ever becomes ready.
+        if not self._ready.is_set():
+            self._ready.set()
+        await self._fan_out(ServerEventType.CLOSED, payload)
+        await self._fan_out_wildcard(ServerEventType.CLOSED, payload)
+        self._closed.set()
+
+    async def _fan_out(
+        self, event_type: ServerEventType, payload: typing.Any
+    ) -> None:
+        for handler in list(self._handlers.get(event_type, [])):
+            await self._safe_call(handler, payload)
+
+    async def _fan_out_wildcard(
+        self,
+        event_type: typing.Union[ServerEventType, str, None],
+        payload: typing.Any,
+    ) -> None:
+        for handler in list(self._wildcard_handlers):
+            await self._safe_call(handler, event_type, payload)
+
+    async def _safe_call(
+        self, handler: typing.Callable[..., typing.Any], *args: typing.Any
+    ) -> None:
+        try:
+            result = handler(*args)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            _log.exception("Handler raised: %s", exc)
+            err = ErrorEvent(
+                message=str(exc),
+                raw={"handler": getattr(handler, "__qualname__", repr(handler))},
+            )
+            for fn in list(self._handlers.get(ServerEventType.ERROR, [])):
+                if fn is handler:
+                    continue
+                try:
+                    res = fn(err)
+                    if inspect.isawaitable(res):
+                        await res
+                except Exception:
+                    _log.exception("Error-handler also raised; dropping")
+
+
+def _build_url(base_url: str, opts: ConnectOptions) -> str:
+    base = base_url.rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://"):]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://"):]
+    query = urlencode(opts.to_query())
+    return f"{base}{_REALTIME_PATH}?{query}"
+
+
+async def connect(
+    api_key: str,
+    *,
+    base_url: str = DEFAULT_REALTIME_BASE_URL,
+    transport: typing.Optional[Transport] = None,
+    extra_headers: typing.Optional[typing.Dict[str, str]] = None,
+    **options: typing.Any,
+) -> RealtimeSession:
+    """Open a realtime translation session.
+
+    For most users the convenience accessor on ``CambAI`` is preferred::
+
+        async with await client.realtime.connect(
+            source_language="en-US",
+            target_language="de-DE",
+        ) as session:
+            ...
+
+    Parameters mirror :class:`~camb.realtime.options.ConnectOptions`
+    (``model``, ``source_language``, ``target_language``, ``output_modalities``).
+    """
+    opts = ConnectOptions(**options)
+    url = _build_url(base_url, opts)
+    headers: typing.Dict[str, str] = extra_headers.copy() if extra_headers else {}
+    session_payload: typing.Dict[str, typing.Any] = {
+        "type": "session.update",
+        "session": opts.to_session_payload(),
+        "auth": {"api_key": api_key},
+    }
+    tport = transport if transport is not None else WebsocketsTransport()
+    session = RealtimeSession(
+        transport=tport,
+        url=url,
+        headers=headers,
+        session_payload=session_payload,
+    )
+    await session._open()
+    return session

--- a/camb/realtime/transport.py
+++ b/camb/realtime/transport.py
@@ -1,0 +1,94 @@
+"""WebSocket transport abstraction for the realtime client.
+
+Mirrors ``camb.live_transcription.transport`` but raises
+:class:`~camb.realtime.errors.RealtimeConnectError` on failure.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from .errors import RealtimeConnectError
+
+
+class Transport(typing.Protocol):
+    """Minimum surface a WebSocket implementation must expose."""
+
+    async def connect(self, url: str, headers: typing.Dict[str, str]) -> None: ...
+
+    async def send_bytes(self, data: bytes) -> None: ...
+
+    async def send_text(self, data: str) -> None: ...
+
+    def __aiter__(self) -> typing.AsyncIterator[typing.Union[str, bytes]]: ...
+
+    async def close(self, code: int = 1000) -> None: ...
+
+    @property
+    def close_code(self) -> typing.Optional[int]: ...
+
+    @property
+    def close_reason(self) -> typing.Optional[str]: ...
+
+
+class WebsocketsTransport:
+    """Default :class:`Transport` backed by the ``websockets`` library."""
+
+    def __init__(self) -> None:
+        self._ws: typing.Any = None
+        self._close_code: typing.Optional[int] = None
+        self._close_reason: typing.Optional[str] = None
+
+    async def connect(self, url: str, headers: typing.Dict[str, str]) -> None:
+        try:
+            import websockets
+        except ImportError as exc:
+            raise RealtimeConnectError(
+                "The 'websockets' package is required for realtime translation."
+            ) from exc
+
+        try:
+            try:
+                self._ws = await websockets.connect(url, additional_headers=headers)
+            except TypeError:
+                self._ws = await websockets.connect(url, extra_headers=headers)
+        except Exception as exc:
+            raise RealtimeConnectError(str(exc)) from exc
+
+    async def send_bytes(self, data: bytes) -> None:
+        await self._ws.send(data)
+
+    async def send_text(self, data: str) -> None:
+        await self._ws.send(data)
+
+    def __aiter__(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        return self._iter()
+
+    async def _iter(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        try:
+            async for frame in self._ws:
+                yield frame
+        except Exception as exc:
+            try:
+                import websockets.exceptions as _ws_exc
+
+                if isinstance(exc, _ws_exc.ConnectionClosed):
+                    self._close_code = exc.code
+                    self._close_reason = exc.reason or ""
+                    return
+            except ImportError:
+                pass
+            raise
+
+    async def close(self, code: int = 1000) -> None:
+        if self._ws is not None:
+            await self._ws.close(code=code)
+            self._close_code = code
+
+    @property
+    def close_code(self) -> typing.Optional[int]:
+        return self._close_code
+
+    @property
+    def close_reason(self) -> typing.Optional[str]:
+        return self._close_reason

--- a/examples/realtime_translation_file.py
+++ b/examples/realtime_translation_file.py
@@ -1,0 +1,115 @@
+"""Realtime speech-to-speech translation from a WAV file.
+
+Streams a local WAV at real-time pace, prints the transcript and translated
+text, and writes the translated audio to an output WAV. Useful on machines
+with no microphone or speaker (CI, servers) to exercise the realtime pipeline
+end to end.
+
+The input WAV must be 16-bit PCM, mono, 24 kHz (the rate the realtime endpoint
+expects). Output is written at the same format.
+
+Run with:
+
+    export CAMB_API_KEY=...
+    python examples/realtime_translation_file.py input_24k_mono.wav [out.wav] [en-US] [es-ES]
+"""
+
+import asyncio
+import os
+import sys
+import wave
+
+from camb.client import CambAI
+from camb.live_transcription import FileAudioSource
+from camb.realtime import ServerEventType
+
+SAMPLE_RATE = 24000
+
+
+async def main(in_path: str, out_path: str, source_language: str, target_language: str) -> None:
+    api_key = os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        print("Set CAMB_API_KEY", file=sys.stderr)
+        sys.exit(2)
+
+    with wave.open(in_path, "rb") as wf:
+        if (wf.getframerate(), wf.getnchannels(), wf.getsampwidth()) != (SAMPLE_RATE, 1, 2):
+            print(
+                f"Warning: expected 24 kHz mono 16-bit PCM; got "
+                f"{wf.getframerate()} Hz, {wf.getnchannels()} ch, {wf.getsampwidth() * 8}-bit. "
+                f"Re-encode with: ffmpeg -i {in_path} -ar 24000 -ac 1 -sample_fmt s16 input_24k_mono.wav",
+                file=sys.stderr,
+            )
+
+    client = CambAI(api_key=api_key)
+    session = await client.realtime.connect(
+        source_language=source_language,
+        target_language=target_language,
+        # iris is the low-latency model (no cold-boot wait).
+        model="iris",
+    )
+
+    out_audio = bytearray()
+    audio_done = asyncio.Event()
+
+    @session.on(ServerEventType.SESSION_STARTING)
+    def _(_):
+        print("Booting the translation pipeline (this can take 30s+)...")
+
+    @session.on(ServerEventType.SESSION_CREATED)
+    def _(_):
+        print(f"Ready. Streaming {os.path.basename(in_path)} ({source_language} -> {target_language})...")
+
+    @session.on(ServerEventType.TRANSCRIPT_COMPLETED)
+    def _(event):
+        print(f"[you]         {event.transcript}")
+
+    @session.on(ServerEventType.TEXT_DONE)
+    def _(event):
+        print(f"[translation] {event.text}")
+
+    @session.on(ServerEventType.AUDIO_DELTA)
+    def _(event):
+        out_audio.extend(event.data)
+
+    @session.on(ServerEventType.AUDIO_DONE)
+    def _(_):
+        audio_done.set()
+
+    @session.on(ServerEventType.ERROR)
+    def _(err):
+        print(f"Server error: {err.message}", file=sys.stderr)
+
+    async with session:
+        await session.wait_until_ready()
+        await session.stream_audio(FileAudioSource(in_path, real_time=True))
+        # Input is exhausted; give the server time to flush the final
+        # translated audio before we close.
+        try:
+            await asyncio.wait_for(audio_done.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            print("(no audio.done within 30s; writing what we received)", file=sys.stderr)
+
+    if out_audio:
+        with wave.open(out_path, "wb") as out:
+            out.setnchannels(1)
+            out.setsampwidth(2)
+            out.setframerate(SAMPLE_RATE)
+            out.writeframes(bytes(out_audio))
+        print(f"Wrote {len(out_audio) / (SAMPLE_RATE * 2):.1f}s of translated audio to {out_path}")
+    else:
+        print("No audio received.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "usage: python examples/realtime_translation_file.py INPUT.wav [OUT.wav] [SRC] [TGT]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    in_path = sys.argv[1]
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "translated_output.wav"
+    src = sys.argv[3] if len(sys.argv) > 3 else "en-US"
+    tgt = sys.argv[4] if len(sys.argv) > 4 else "es-ES"
+    asyncio.run(main(in_path, out_path, src, tgt))

--- a/examples/realtime_translation_microphone.py
+++ b/examples/realtime_translation_microphone.py
@@ -1,0 +1,130 @@
+"""Realtime speech-to-speech translation from the microphone.
+
+Speak into your mic in the source language; the translated speech is played
+back through your speakers in near real time, and the translated text is
+printed as it arrives.
+
+Audio is PCM16 mono at 24 kHz in both directions.
+
+Run with:
+
+    pip install camb-sdk
+    CAMB_API_KEY=... python examples/realtime_translation_microphone.py
+
+Optionally override the languages:
+
+    CAMB_API_KEY=... python examples/realtime_translation_microphone.py en-US de-DE
+"""
+
+import asyncio
+import os
+import sys
+import threading
+
+import sounddevice as sd
+
+from camb.client import CambAI
+from camb.live_transcription import Microphone
+from camb.realtime import ServerEventType
+
+SAMPLE_RATE = 24000  # PCM16 mono, both directions
+
+
+class Speaker:
+    """Plays raw PCM16 mono bytes through the default output device.
+
+    A background PortAudio callback drains a thread-safe buffer that the
+    realtime audio handler fills, so playback never blocks the event loop.
+    """
+
+    def __init__(self, sample_rate: int = SAMPLE_RATE) -> None:
+        self._buf = bytearray()
+        self._lock = threading.Lock()
+        self._stream = sd.RawOutputStream(
+            samplerate=sample_rate, channels=1, dtype="int16", callback=self._callback
+        )
+
+    def _callback(self, outdata, frames, time_info, status) -> None:  # noqa: ANN001
+        want = len(outdata)
+        with self._lock:
+            take = min(want, len(self._buf))
+            outdata[:take] = bytes(self._buf[:take])
+            del self._buf[:take]
+        if take < want:
+            outdata[take:] = b"\x00" * (want - take)  # underrun → silence
+
+    def start(self) -> None:
+        self._stream.start()
+
+    def feed(self, pcm: bytes) -> None:
+        with self._lock:
+            self._buf.extend(pcm)
+
+    def close(self) -> None:
+        self._stream.stop()
+        self._stream.close()
+
+
+async def main(source_language: str, target_language: str) -> None:
+    api_key = os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        print("Set CAMB_API_KEY", file=sys.stderr)
+        sys.exit(2)
+
+    client = CambAI(api_key=api_key)
+    session = await client.realtime.connect(
+        source_language=source_language,
+        target_language=target_language,
+        # iris is the low-latency model (no cold-boot wait).
+        model="iris",
+    )
+
+    speaker = Speaker()
+
+    @session.on(ServerEventType.SESSION_STARTING)
+    def _(_):
+        print("Booting the translation pipeline (this can take 30s+)...")
+
+    @session.on(ServerEventType.SESSION_CREATED)
+    def _(_):
+        print(f"Ready. Speak in {source_language}; you'll hear {target_language}. Ctrl-C to stop.")
+
+    @session.on(ServerEventType.TRANSCRIPT_COMPLETED)
+    def _(event):
+        print(f"\n[you]         {event.transcript}")
+
+    @session.on(ServerEventType.TEXT_DONE)
+    def _(event):
+        print(f"[translation] {event.text}")
+
+    @session.on(ServerEventType.AUDIO_DELTA)
+    def _(event):
+        speaker.feed(event.data)
+
+    @session.on(ServerEventType.ERROR)
+    def _(err):
+        print(f"\nServer error: {err.message}", file=sys.stderr)
+
+    @session.on(ServerEventType.CLOSED)
+    def _(info):
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+
+    async with session:
+        await session.wait_until_ready()
+        speaker.start()
+        mic = Microphone(sample_rate=SAMPLE_RATE, chunk_size=SAMPLE_RATE // 10)
+        try:
+            await session.stream_audio(mic)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            speaker.close()
+
+
+if __name__ == "__main__":
+    src = sys.argv[1] if len(sys.argv) > 1 else "en-US"
+    tgt = sys.argv[2] if len(sys.argv) > 2 else "es-ES"
+    try:
+        asyncio.run(main(src, tgt))
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
Implements camb.realtime, a new module that wraps the /v1/realtime WebSocket endpoint. Mirrors the live_transcription module's session, event dispatch, and transport patterns. Key behaviours:

- connect() opens the WS, sends session.update with auth and config, and returns immediately; callers register handlers then await session.wait_until_ready() (90 s timeout) for session.created
- Binary frames and JSON response.audio.delta both dispatch to AudioDeltaEvent with uniform data: bytes — handlers see no difference
- session.starting is a supported event so callers can show a loading indicator during the 30+ s cold-boot of non-iris models
- stream_audio() accepts any AsyncIterable[bytes], making it compatible with live_transcription.Microphone and FileAudioSource

Wires client.realtime property onto both CambAI and AsyncCambAI.