### PR TITLE
examples: realtime speech-to-speech translation (mic + file)

### DIFF
--- a/examples/realtime_translation_file.py
+++ b/examples/realtime_translation_file.py
@@ -1,0 +1,115 @@
+"""Realtime speech-to-speech translation from a WAV file.
+
+Streams a local WAV at real-time pace, prints the transcript and translated
+text, and writes the translated audio to an output WAV. Useful on machines
+with no microphone or speaker (CI, servers) to exercise the realtime pipeline
+end to end.
+
+The input WAV must be 16-bit PCM, mono, 24 kHz (the rate the realtime endpoint
+expects). Output is written at the same format.
+
+Run with:
+
+    export CAMB_API_KEY=...
+    python examples/realtime_translation_file.py input_24k_mono.wav [out.wav] [en-US] [es-ES]
+"""
+
+import asyncio
+import os
+import sys
+import wave
+
+from camb.client import CambAI
+from camb.live_transcription import FileAudioSource
+from camb.realtime import ServerEventType
+
+SAMPLE_RATE = 24000
+
+
+async def main(in_path: str, out_path: str, source_language: str, target_language: str) -> None:
+    api_key = os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        print("Set CAMB_API_KEY", file=sys.stderr)
+        sys.exit(2)
+
+    with wave.open(in_path, "rb") as wf:
+        if (wf.getframerate(), wf.getnchannels(), wf.getsampwidth()) != (SAMPLE_RATE, 1, 2):
+            print(
+                f"Warning: expected 24 kHz mono 16-bit PCM; got "
+                f"{wf.getframerate()} Hz, {wf.getnchannels()} ch, {wf.getsampwidth() * 8}-bit. "
+                f"Re-encode with: ffmpeg -i {in_path} -ar 24000 -ac 1 -sample_fmt s16 input_24k_mono.wav",
+                file=sys.stderr,
+            )
+
+    client = CambAI(api_key=api_key)
+    session = await client.realtime.connect(
+        source_language=source_language,
+        target_language=target_language,
+        # iris is the low-latency model (no cold-boot wait).
+        model="iris",
+    )
+
+    out_audio = bytearray()
+    audio_done = asyncio.Event()
+
+    @session.on(ServerEventType.SESSION_STARTING)
+    def _(_):
+        print("Booting the translation pipeline (this can take 30s+)...")
+
+    @session.on(ServerEventType.SESSION_CREATED)
+    def _(_):
+        print(f"Ready. Streaming {os.path.basename(in_path)} ({source_language} -> {target_language})...")
+
+    @session.on(ServerEventType.TRANSCRIPT_COMPLETED)
+    def _(event):
+        print(f"[you]         {event.transcript}")
+
+    @session.on(ServerEventType.TEXT_DONE)
+    def _(event):
+        print(f"[translation] {event.text}")
+
+    @session.on(ServerEventType.AUDIO_DELTA)
+    def _(event):
+        out_audio.extend(event.data)
+
+    @session.on(ServerEventType.AUDIO_DONE)
+    def _(_):
+        audio_done.set()
+
+    @session.on(ServerEventType.ERROR)
+    def _(err):
+        print(f"Server error: {err.message}", file=sys.stderr)
+
+    async with session:
+        await session.wait_until_ready()
+        await session.stream_audio(FileAudioSource(in_path, real_time=True))
+        # Input is exhausted; give the server time to flush the final
+        # translated audio before we close.
+        try:
+            await asyncio.wait_for(audio_done.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            print("(no audio.done within 30s; writing what we received)", file=sys.stderr)
+
+    if out_audio:
+        with wave.open(out_path, "wb") as out:
+            out.setnchannels(1)
+            out.setsampwidth(2)
+            out.setframerate(SAMPLE_RATE)
+            out.writeframes(bytes(out_audio))
+        print(f"Wrote {len(out_audio) / (SAMPLE_RATE * 2):.1f}s of translated audio to {out_path}")
+    else:
+        print("No audio received.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "usage: python examples/realtime_translation_file.py INPUT.wav [OUT.wav] [SRC] [TGT]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    in_path = sys.argv[1]
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "translated_output.wav"
+    src = sys.argv[3] if len(sys.argv) > 3 else "en-US"
+    tgt = sys.argv[4] if len(sys.argv) > 4 else "es-ES"
+    asyncio.run(main(in_path, out_path, src, tgt))

--- a/examples/realtime_translation_microphone.py
+++ b/examples/realtime_translation_microphone.py
@@ -1,0 +1,130 @@
+"""Realtime speech-to-speech translation from the microphone.
+
+Speak into your mic in the source language; the translated speech is played
+back through your speakers in near real time, and the translated text is
+printed as it arrives.
+
+Audio is PCM16 mono at 24 kHz in both directions.
+
+Run with:
+
+    pip install camb-sdk
+    CAMB_API_KEY=... python examples/realtime_translation_microphone.py
+
+Optionally override the languages:
+
+    CAMB_API_KEY=... python examples/realtime_translation_microphone.py en-US de-DE
+"""
+
+import asyncio
+import os
+import sys
+import threading
+
+import sounddevice as sd
+
+from camb.client import CambAI
+from camb.live_transcription import Microphone
+from camb.realtime import ServerEventType
+
+SAMPLE_RATE = 24000  # PCM16 mono, both directions
+
+
+class Speaker:
+    """Plays raw PCM16 mono bytes through the default output device.
+
+    A background PortAudio callback drains a thread-safe buffer that the
+    realtime audio handler fills, so playback never blocks the event loop.
+    """
+
+    def __init__(self, sample_rate: int = SAMPLE_RATE) -> None:
+        self._buf = bytearray()
+        self._lock = threading.Lock()
+        self._stream = sd.RawOutputStream(
+            samplerate=sample_rate, channels=1, dtype="int16", callback=self._callback
+        )
+
+    def _callback(self, outdata, frames, time_info, status) -> None:  # noqa: ANN001
+        want = len(outdata)
+        with self._lock:
+            take = min(want, len(self._buf))
+            outdata[:take] = bytes(self._buf[:take])
+            del self._buf[:take]
+        if take < want:
+            outdata[take:] = b"\x00" * (want - take)  # underrun → silence
+
+    def start(self) -> None:
+        self._stream.start()
+
+    def feed(self, pcm: bytes) -> None:
+        with self._lock:
+            self._buf.extend(pcm)
+
+    def close(self) -> None:
+        self._stream.stop()
+        self._stream.close()
+
+
+async def main(source_language: str, target_language: str) -> None:
+    api_key = os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        print("Set CAMB_API_KEY", file=sys.stderr)
+        sys.exit(2)
+
+    client = CambAI(api_key=api_key)
+    session = await client.realtime.connect(
+        source_language=source_language,
+        target_language=target_language,
+        # iris is the low-latency model (no cold-boot wait).
+        model="iris",
+    )
+
+    speaker = Speaker()
+
+    @session.on(ServerEventType.SESSION_STARTING)
+    def _(_):
+        print("Booting the translation pipeline (this can take 30s+)...")
+
+    @session.on(ServerEventType.SESSION_CREATED)
+    def _(_):
+        print(f"Ready. Speak in {source_language}; you'll hear {target_language}. Ctrl-C to stop.")
+
+    @session.on(ServerEventType.TRANSCRIPT_COMPLETED)
+    def _(event):
+        print(f"\n[you]         {event.transcript}")
+
+    @session.on(ServerEventType.TEXT_DONE)
+    def _(event):
+        print(f"[translation] {event.text}")
+
+    @session.on(ServerEventType.AUDIO_DELTA)
+    def _(event):
+        speaker.feed(event.data)
+
+    @session.on(ServerEventType.ERROR)
+    def _(err):
+        print(f"\nServer error: {err.message}", file=sys.stderr)
+
+    @session.on(ServerEventType.CLOSED)
+    def _(info):
+        print(f"\nClosed: code={info.code} reason={info.reason!r}")
+
+    async with session:
+        await session.wait_until_ready()
+        speaker.start()
+        mic = Microphone(sample_rate=SAMPLE_RATE, chunk_size=SAMPLE_RATE // 10)
+        try:
+            await session.stream_audio(mic)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            speaker.close()
+
+
+if __name__ == "__main__":
+    src = sys.argv[1] if len(sys.argv) > 1 else "en-US"
+    tgt = sys.argv[2] if len(sys.argv) > 2 else "es-ES"
+    try:
+        asyncio.run(main(src, tgt))
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
Adds two runnable examples for the new `camb.realtime` module (this PR targets the realtime feature branch, not `main`):

- **`examples/realtime_translation_microphone.py`** — mic in (24 kHz PCM16) → plays translated audio out via `sounddevice`, prints translated text. Run: `CAMB_API_KEY=… python examples/realtime_translation_microphone.py [src] [tgt]`
- **`examples/realtime_translation_file.py`** — streams a 24 kHz mono WAV → writes translated audio to an output WAV (headless-testable, no mic/speaker needed).

Both follow the documented protocol exactly: `connect()` → `session.update` → `wait_until_ready()` → stream `input_audio_buffer.append` → handle `AUDIO_DELTA`/`TEXT_DONE`/`TRANSCRIPT_COMPLETED`. Audio is PCM16 mono 24 kHz in both directions.

## Live testing notes (realtime.camb.ai)
Validated against the live endpoint. Per-model results:

| model | session.created | translated audio | text/transcript |
|---|---|---|---|
| **iris** | ✅ | ✅ ~full clip | none observed |
| lilac | ✅ | ✗ (silent → 1006) | none |
| orchid | ✅ | ✗ (silent → 1006) | none |
| violet | ✗ (timeout) | ✗ | none |

So the examples default to **`model="iris"`** — the only model returning translated audio in testing. Note the SDK's own default is `lilac` (`options.py`), which returned no output; worth a look. No model emitted `response.text.*` / `transcript.completed` events in testing (audio-only output), so the examples' text printing will currently stay blank while audio works.

## Test plan
- [ ] `CAMB_API_KEY=… python examples/realtime_translation_file.py input_24k_mono.wav` → writes translated WAV
- [ ] `CAMB_API_KEY=… python examples/realtime_translation_microphone.py` → hear translated audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)