### PR TITLE
fix: make `from camb import CambAI` work (runtime import map)

### DIFF
--- a/camb/__init__.py
+++ b/camb/__init__.py
@@ -112,10 +112,10 @@ if typing.TYPE_CHECKING:
     from .voice_cloning import ListVoicesListVoicesGetResponseItem
 _dynamic_imports: typing.Dict[str, str] = {
     "AddTargetLanguageOut": ".types",
-    "AsyncCambApi": ".client",
+    "AsyncCambAI": ".client",
     "AudioOutputType": ".types",
     "AudioStream": ".types",
-    "CambApi": ".client",
+    "CambAI": ".client",
     "CambApiEnvironment": ".environment",
     "ConfigStream": ".types",
     "ConfigStreamPipeline": ".types",


### PR DESCRIPTION
## Problem
`from camb import CambAI` raises `ImportError: cannot import name 'CambAI' from 'camb'` (suggests `CambApi`), even though `CambAI` is in `__all__` and the `TYPE_CHECKING` block.

The client class was rebranded `CambApi` → `CambAI`. The class definition (`camb/client.py`), `__all__`, and the `TYPE_CHECKING` imports were all updated, but the **runtime** lazy-import map `_dynamic_imports` was not — it still mapped the now-nonexistent `CambApi`/`AsyncCambApi` to `.client`. So `__getattr__("CambAI")` finds nothing and raises.

This affects `main` (not just a feature branch) and breaks the documented top-level import used in the SDK tutorials.

## Fix
Point the two map entries at the real class names:
- `"AsyncCambApi": ".client"` → `"AsyncCambAI": ".client"`
- `"CambApi": ".client"` → `"CambAI": ".client"`

## Verification
```
python -c "from camb import CambAI, AsyncCambAI; print('OK', CambAI.__name__, AsyncCambAI.__name__)"
# OK CambAI AsyncCambAI
```

Note: some Fern-generated docstrings in `client.py` still show `from camb import CambApi` — separate cosmetic cleanup, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)