### PR TITLE
`[to-main]` feat(realtime): add voice_id option for cloned-voice synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,69 @@ For the full event catalog (`Ready`, `Results`, `Final`, `Error`,
 [Live Transcription tutorial](https://docs.camb.ai/tutorials/live-transcription-with-sdk)
 and [SDK guide](https://docs.camb.ai/sdk-guides/live-transcription).
 
+### 6. Realtime Speech-to-Speech Translation (Streaming WebSocket)
+
+Speak (or stream a file) in one language and receive the translation as live
+text and synthesized speech over a single WebSocket. Audio is PCM16 mono at
+24 kHz in both directions.
+
+```python
+import asyncio
+import os
+
+from camb.client import CambAI
+from camb.live_transcription import Microphone
+from camb.realtime import ServerEventType
+
+
+async def main():
+    client = CambAI(api_key=os.environ["CAMB_API_KEY"])
+    session = await client.realtime.connect(
+        source_language="en-us",
+        target_language="de-de",
+    )
+
+    @session.on(ServerEventType.TEXT_DONE)
+    def _(event):
+        print(f"[translation] {event.text}")
+
+    @session.on(ServerEventType.AUDIO_DELTA)
+    def _(event):
+        ...  # event.data is raw PCM16 mono 24 kHz — play it through your speakers
+
+    async with session:
+        await session.wait_until_ready()
+        mic = Microphone(sample_rate=24000, chunk_size=2400)
+        await session.stream_audio(mic)
+
+
+asyncio.run(main())
+```
+
+By default the translation is synthesized with a built-in voice for the target
+language. Pass `voice_id` to use one of your cloned voices instead (get the ID
+from `client.voice_cloning.list_voices()`):
+
+```python
+session = await client.realtime.connect(
+    source_language="en-us",
+    target_language="de-de",
+    voice_id=147320,  # one of your cloned voices
+)
+```
+
+For the most natural-sounding results, choose a voice whose reference language
+matches `target_language`.
+
+Runnable examples:
+[`examples/realtime_translation_microphone.py`](examples/realtime_translation_microphone.py)
+(mic in, translated speech out) and
+[`examples/realtime_translation_file.py`](examples/realtime_translation_file.py)
+(WAV in, translated WAV out — no audio device needed). For the full event
+list and configuration, see the
+[Realtime Speech Translation tutorial](https://docs.camb.ai/tutorials/realtime-translation-with-sdk)
+and the [WebSocket API reference](https://docs.camb.ai/api-reference/websockets/realtime).
+
 ## ⚙️ Advanced Usage & Other Features
 
 The Camb AI SDK offers a wide range of capabilities beyond these examples, including:

--- a/camb/realtime/client.py
+++ b/camb/realtime/client.py
@@ -61,6 +61,8 @@ class RealtimeClient:
         - ``target_language`` *(required)* — IETF BCP-47 tag, e.g. ``"de-DE"``
         - ``model`` — one of ``"lilac"`` (default), ``"violet"``, ``"iris"``, ``"orchid"``
         - ``output_modalities`` — list of ``"text"`` and/or ``"audio"`` (default: both)
+        - ``voice_id`` — ID of one of your cloned voices to synthesize the
+          translation with (default: a built-in voice for ``target_language``)
 
         Returns an open :class:`~camb.realtime.session.RealtimeSession`.  The
         session is not yet ready to accept audio; call

--- a/camb/realtime/options.py
+++ b/camb/realtime/options.py
@@ -35,6 +35,16 @@ class ConnectOptions(pydantic.BaseModel):
     output_modalities: typing.List[OutputModality] = pydantic.Field(
         default_factory=lambda: [OutputModality.TEXT, OutputModality.AUDIO]
     )
+    voice_id: typing.Optional[int] = None
+    """Synthesize the translation with one of your cloned voices.
+
+    Pass the ID of a voice you own (from ``client.voice_cloning.list_voices()``
+    or a custom voice you created). When omitted, a built-in voice for
+    ``target_language`` is used.
+
+    For the most natural-sounding results, choose a voice whose reference
+    language matches ``target_language``.
+    """
 
     def to_query(self) -> typing.Dict[str, str]:
         """Query-string parameters sent on the WebSocket upgrade URL."""
@@ -42,9 +52,12 @@ class ConnectOptions(pydantic.BaseModel):
 
     def to_session_payload(self) -> typing.Dict[str, typing.Any]:
         """Body of the ``session.update`` message sent after the WS handshake."""
-        return {
+        session: typing.Dict[str, typing.Any] = {
             "model": self.model.value,
             "source_language": self.source_language,
             "target_language": self.target_language,
             "output_modalities": [m.value for m in self.output_modalities],
         }
+        if self.voice_id is not None:
+            session["voice"] = {"type": "cloned", "voice_id": self.voice_id}
+        return session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "camb-sdk"
-version = "1.5.13"
+version = "1.5.14"
 readme = "README.md"
 description = "The official Python SDK for the Camb.ai API"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="camb-sdk",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version="1.5.13",
+    version="1.5.14",
     packages=find_packages(where="."),
     package_dir={"": "."},
     install_requires=[


### PR DESCRIPTION
Let realtime sessions synthesize the translation with one of the
caller's cloned voices instead of the built-in default.

ConnectOptions gains an optional voice_id; when set, to_session_payload
emits `voice: {type: "cloned", voice_id}` in the session.update message.
Omitting it preserves the previous behavior (built-in voice for the
target language). voice_id flows through connect(**options) unchanged.
