### PR TITLE
`[to-main]` fix(live_transcription): point at dedicated realtime.camb.ai endpoint

### DIFF
--- a/camb/live_transcription/__init__.py
+++ b/camb/live_transcription/__init__.py
@@ -1,7 +1,8 @@
 """Live transcription WebSocket client.
 
-This package wraps the ``/apis/transcription/listen`` WebSocket endpoint
-documented in ``public_docs/api-reference/websockets/listen.mdx``.
+This package wraps the ``wss://realtime.camb.ai/streaming-transcription/listen``
+WebSocket endpoint documented in
+``public_docs/api-reference/websockets/listen.mdx``.
 
 Quick start::
 

--- a/camb/live_transcription/client.py
+++ b/camb/live_transcription/client.py
@@ -6,7 +6,11 @@ import typing
 
 from ..core.client_wrapper import SyncClientWrapper
 from .errors import LiveTranscriptionConnectError
-from .session import LiveTranscriptionSession, connect as _connect
+from .session import (
+    DEFAULT_LIVE_TRANSCRIPTION_BASE_URL,
+    LiveTranscriptionSession,
+    connect as _connect,
+)
 
 
 class LiveTranscriptionClient:
@@ -36,7 +40,7 @@ class LiveTranscriptionClient:
             )
         return await _connect(
             api_key=api_key,
-            base_url=self._client_wrapper.get_base_url(),
+            base_url=DEFAULT_LIVE_TRANSCRIPTION_BASE_URL,
             extra_headers=self._client_wrapper.get_custom_headers(),
             **options,
         )

--- a/camb/live_transcription/session.py
+++ b/camb/live_transcription/session.py
@@ -257,8 +257,14 @@ class LiveTranscriptionSession:
                     _log.exception("Error-handler also raised; dropping")
 
 
+# Live transcription runs on the dedicated realtime host, independent of the
+# REST API base URL. Mirrors camb.realtime's DEFAULT_REALTIME_BASE_URL.
+DEFAULT_LIVE_TRANSCRIPTION_BASE_URL = "wss://realtime.camb.ai"
+_LIVE_TRANSCRIPTION_PATH = "/streaming-transcription/listen"
+
+
 def _build_url(base_url: str, options: ConnectOptions) -> str:
-    """Convert the SDK's HTTP base URL into the live transcription WSS URL."""
+    """Build the live transcription WSS URL from its base URL."""
     from urllib.parse import urlencode
 
     base = base_url.rstrip("/")
@@ -267,13 +273,13 @@ def _build_url(base_url: str, options: ConnectOptions) -> str:
     elif base.startswith("http://"):
         base = "ws://" + base[len("http://"):]
     query = urlencode(options.to_query())
-    return f"{base}/transcription/listen?{query}"
+    return f"{base}{_LIVE_TRANSCRIPTION_PATH}?{query}"
 
 
 async def connect(
     api_key: str,
     *,
-    base_url: str = "https://client.camb.ai/apis",
+    base_url: str = DEFAULT_LIVE_TRANSCRIPTION_BASE_URL,
     transport: typing.Optional[Transport] = None,
     extra_headers: typing.Optional[typing.Dict[str, str]] = None,
     **options: typing.Any,


### PR DESCRIPTION
Live transcription now connects to
wss://realtime.camb.ai/streaming-transcription/listen instead of
deriving
its URL from the REST base_url
(client.camb.ai/apis/transcription/listen).
The streaming-transcription service runs on the dedicated realtime host,
so
its WebSocket URL should not be coupled to the REST API host.

Mirrors the existing camb.realtime client: a dedicated
DEFAULT_LIVE_TRANSCRIPTION_BASE_URL constant that the resource accessor
passes through, rather than the shared client_wrapper base_url. REST
calls
and the realtime (S2S) client are unaffected, and an explicit base_url
override (e.g. https://dev-realtime.camb.ai) still resolves correctly.
