### PR TITLE
docs: fix broken import, wrong variable name, and stale class references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ except Exception as e:
 Generate sound effects or ambient audio from a descriptive prompt.
 
 ```python
-from camb.client save_stream_to_file
+from camb.client import save_stream_to_file
 import time
 
 response = client.text_to_audio.create_text_to_audio(
@@ -270,7 +270,7 @@ result = client.dub.create_dub(
     target_languages=[Languages.HI_IN],  # list of Languages like [Languages.HI_IN, Languages.FR_FR] or if you want single language then can use target_language=Languages.HI_IN
     transcription_mode="fast",  # fast (default) or slow for a more thorough transcription pass
 )
-task_id = response.task_id
+task_id = result.task_id
 print(f"Dub Task created with ID: {task_id}")
 while True:
     status_response = client.dub.get_dubbing_status(task_id=task_id)
@@ -278,8 +278,8 @@ while True:
     if status_response.status == "SUCCESS":
         dubbed_run_info = client.dub.get_dubbed_run_info(status_response.run_id)
         print(f"Dubbed Video URL: {dubbed_run_info.audio_url}")
-        print(f"Dubbed Video URL: {dubbed_run_info.transcript}")
-        print(f"Dubbed Video URL: {dubbed_run_info.video_url}")
+        print(f"Transcript: {dubbed_run_info.transcript}")
+        print(f"Video URL: {dubbed_run_info.video_url}")
         break
     time.sleep(5)
 ```

--- a/camb/transcription/client.py
+++ b/camb/transcription/client.py
@@ -68,7 +68,7 @@ class TranscriptionClient:
             See core.File for more documentation
 
         audio_url : typing.Optional[str]
-            [DEPRECATED] Use 'audio_url' instead
+            [DEPRECATED] Use 'media_url' instead
 
         project_name : typing.Optional[str]
 
@@ -296,7 +296,7 @@ class AsyncTranscriptionClient:
             See core.File for more documentation
 
         audio_url : typing.Optional[str]
-            [DEPRECATED] Use 'audio_url' instead
+            [DEPRECATED] Use 'media_url' instead
 
         project_name : typing.Optional[str]
 

--- a/camb/transcription/raw_client.py
+++ b/camb/transcription/raw_client.py
@@ -65,7 +65,7 @@ class RawTranscriptionClient:
             See core.File for more documentation
 
         audio_url : typing.Optional[str]
-            [DEPRECATED] Use 'audio_url' instead
+            [DEPRECATED] Use 'media_url' instead
 
         project_name : typing.Optional[str]
 
@@ -365,7 +365,7 @@ class AsyncRawTranscriptionClient:
             See core.File for more documentation
 
         audio_url : typing.Optional[str]
-            [DEPRECATED] Use 'audio_url' instead
+            [DEPRECATED] Use 'media_url' instead
 
         project_name : typing.Optional[str]
 


### PR DESCRIPTION
The README has a few copy-paste errors that break examples for new users:

1. **Line 240:** `from camb.client save_stream_to_file` is missing the `import` keyword
2. **Line 273:** `task_id = response.task_id` references `response` but the variable is named `result`
3. **Lines 281–282:** Print statements say "Dubbed Video URL" for transcript and video fields (copy-paste)

Also fixes the `audio_url` deprecation docstring in `transcription/client.py` which
incorrectly tells users to "Use 'audio_url' instead" (should be 'media_url').

### Changes
- `README.md`: fix broken import in the Text-to-Audio example, correct the variable name in the dubbing example, and fix copy-pasted print labels
- `camb/transcription/client.py`: fix the deprecated `audio_url` docstring to reference `media_url` in both `TranscriptionClient` and `AsyncTranscriptionClient`

### Testing
- No code changes — docs and docstrings only
- `python3 -m py_compile camb/transcription/client.py` passes