### PR TITLE
feat: fall back to CAMB_API_KEY environment variable when api_key is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ To use the Camb AI SDK, you'll need an API key. You can authenticate it by:
 ```python
 from camb.client import CambAI, AsyncCambAI
 
+# The SDK automatically reads the CAMB_API_KEY environment variable:
+#   export CAMB_API_KEY=your_key_here
+#   client = CambAI()
+
+# Or pass the key explicitly:
+
 # Synchronous Client
 client = CambAI(api_key="YOUR_CAMB_API_KEY")
 

--- a/camb/client.py
+++ b/camb/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import typing
 
 import httpx
@@ -79,7 +80,10 @@ class CambAI:
 
 
 
-    api_key : str
+    api_key : typing.Optional[str]
+        Your Camb AI API key. If not provided, the ``CAMB_API_KEY`` environment
+        variable is used.
+
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -114,8 +118,13 @@ class CambAI:
         tts_provider: typing.Optional[TtsProvider] = None,
         provider_params: typing.Optional[typing.Dict[str, typing.Any]] = None,
     ):
+        if api_key is None:
+            api_key = os.environ.get("CAMB_API_KEY") or None
         if api_key is None and (tts_provider is None or provider_params is None):
-            raise ValueError("Please provide either 'api_key' or both 'tts_provider' and 'provider_params'.")
+            raise ValueError(
+                "Please provide 'api_key', set the CAMB_API_KEY environment variable, "
+                "or provide both 'tts_provider' and 'provider_params'."
+            )
             
         _defaulted_timeout = (
             timeout if timeout is not None else DEFAULT_TIMEOUT if httpx_client is None else httpx_client.timeout.read
@@ -419,7 +428,10 @@ class AsyncCambAI:
 
 
 
-    api_key : str
+    api_key : typing.Optional[str]
+        Your Camb AI API key. If not provided, the ``CAMB_API_KEY`` environment
+        variable is used.
+
     headers : typing.Optional[typing.Dict[str, str]]
         Additional headers to send with every request.
 
@@ -454,8 +466,13 @@ class AsyncCambAI:
         tts_provider: typing.Optional[TtsProvider] = None,
         provider_params: typing.Optional[typing.Dict[str, typing.Any]] = None,
     ):
+        if api_key is None:
+            api_key = os.environ.get("CAMB_API_KEY") or None
         if api_key is None and (tts_provider is None or provider_params is None):
-            raise ValueError("Please provide either 'api_key' or both 'tts_provider' and 'provider_params'.")
+            raise ValueError(
+                "Please provide 'api_key', set the CAMB_API_KEY environment variable, "
+                "or provide both 'tts_provider' and 'provider_params'."
+            )
 
         _defaulted_timeout = (
             timeout if timeout is not None else DEFAULT_TIMEOUT if httpx_client is None else httpx_client.timeout.read


### PR DESCRIPTION
Every example in the repo already uses `os.environ["CAMB_API_KEY"]`, and this is
standard practice for Python API SDKs (OpenAI, Anthropic, Stripe, etc.).

This PR makes the client automatically read the `CAMB_API_KEY` environment variable
when `api_key` is not explicitly passed, removing the need for users to manually
read it themselves.

Usage:
```bash
export CAMB_API_KEY=your_key
```

```python
# Before: required explicit api_key
client = CambAI(api_key=os.environ["CAMB_API_KEY"])

# After: automatically reads from env
client = CambAI()
```

### Changes
- `camb/client.py`:
  - `CambAI.__init__` and `AsyncCambAI.__init__` fall back to `os.environ.get("CAMB_API_KEY")` when `api_key` is not provided
  - Updated the `api_key` param docstrings for both classes
  - Error message updated to mention the env var option
- `README.md`: authentication section now documents the env var fallback

### Testing
Verified offline (no API calls) with both sync and async clients:
- Env var fallback works for `CambAI()` and `AsyncCambAI()`
- Explicit `api_key` still overrides the env var
- Missing key and env var raises `ValueError` mentioning `CAMB_API_KEY`
- `tts_provider` + `provider_params` path still works without `api_key`