### PR TITLE
chore: align python_requires with README and CI (>=3.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "httpx>=0.21.2",
   "pydantic>=1.10.0",

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     ],
     package_data={"camb": ["py.typed"]},
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
## What

The package metadata declares Python >=3.8 while the README documents 3.9+ and CI (installer.yml) only tests 3.9–3.13.

- `pyproject.toml`: `requires-python = ">=3.9"`
- `setup.py`: `python_requires=">=3.9"`

## Why

Metadata should match the documented and tested reality; declaring 3.8 support that is neither documented nor tested can mislead users on 3.8.