### PR TITLE
fix: run async file writes in a thread to avoid blocking the event loop

### DIFF
--- a/camb/client.py
+++ b/camb/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import typing
 
@@ -58,9 +59,13 @@ async def save_async_stream_to_file(stream: typing.AsyncIterable[bytes], filenam
     filename : str
         The name of the file to save the stream to.
     """
-    with open(filename, "wb") as f:
+    # File I/O is run via asyncio.to_thread so the event loop is never blocked.
+    f = await asyncio.to_thread(open, filename, "wb")
+    try:
         async for chunk in stream:
-            f.write(chunk)
+            await asyncio.to_thread(f.write, chunk)
+    finally:
+        await asyncio.to_thread(f.close)
 
 class CambAI:
     """


### PR DESCRIPTION
## What

`save_async_stream_to_file` in `camb/client.py` performed blocking `open()`/`write()`/`close()` calls directly on the event loop, stalling all other coroutines while writing audio chunks (sometimes hundreds of MB).

Uses `asyncio.to_thread` so file I/O runs in the default executor instead:

```python
f = await asyncio.to_thread(open, filename, "wb")
try:
    async for chunk in stream:
        await asyncio.to_thread(f.write, chunk)
finally:
    await asyncio.to_thread(f.close)
```

## Why this approach

- Zero new dependencies (no `aiofiles` added)
- `asyncio.to_thread` requires Python 3.9+, which matches the package metadata after #37 bumps `requires-python` to `>=3.9`
- Preserves true streaming — a chunk is only buffered until its write completes, no whole-file accumulation

Verified by writing 512KB in 1000 chunks via the function (byte-for-byte correct output).