### PR TITLE
feat: add async context manager support to Microphone

### DIFF
--- a/camb/live_transcription/microphone.py
+++ b/camb/live_transcription/microphone.py
@@ -89,3 +89,10 @@ class Microphone:
 
     def __exit__(self, *exc: typing.Any) -> None:
         self.stop()
+
+    async def __aenter__(self) -> "Microphone":
+        self.start()
+        return self
+
+    async def __aexit__(self, *exc: typing.Any) -> None:
+        await self.close()


### PR DESCRIPTION
## What

`camb/live_transcription/microphone.py` had `__enter__`/`__exit__` but no `__aenter__`/`__aexit__` — yet the primary usage is async (`async for chunk in mic`). Adds the async dunders, mirroring the sync ones:

```python
async with Microphone(sample_rate=16000, chunk_size=1600) as mic:
    await session.stream_audio(mic)
# stream stopped + closed here, even on exceptions
```

## Why

The natural pattern for an async-iterable capture source is `async with`, giving deterministic cleanup without manually calling `mic.close()` (which `session.stream_audio` alone only does on exhaustion/exit).

Calling `start()` is safe when already running (no-op guard), so nesting `async with` over an already-started mic is fine.