### PR TITLE
feat: add context manager support to CambAI and AsyncCambAI

### DIFF
--- a/camb/client.py
+++ b/camb/client.py
@@ -164,6 +164,12 @@ class CambAI:
         self._live_transcription: typing.Optional[typing.Any] = None
         self._realtime: typing.Optional[typing.Any] = None
 
+    def __enter__(self) -> "CambAI":
+        return self
+
+    def __exit__(self, *exc: typing.Any) -> None:
+        self._client_wrapper.httpx_client.close()
+
     @property
     def with_raw_response(self) -> RawCambApi:
         """
@@ -511,6 +517,12 @@ class AsyncCambAI:
         self._deprecated_streaming: typing.Optional[AsyncDeprecatedStreamingClient] = None
         self._live_transcription: typing.Optional[typing.Any] = None
         self._realtime: typing.Optional[typing.Any] = None
+
+    async def __aenter__(self) -> "AsyncCambAI":
+        return self
+
+    async def __aexit__(self, *exc: typing.Any) -> None:
+        await self._client_wrapper.httpx_client.aclose()
 
     @property
     def with_raw_response(self) -> AsyncRawCambApi:

--- a/camb/core/http_client.py
+++ b/camb/core/http_client.py
@@ -439,6 +439,9 @@ class HttpClient:
         ) as stream:
             yield stream
 
+    def close(self) -> None:
+        self.httpx_client.close()
+
 
 class AsyncHttpClient:
     def __init__(
@@ -661,3 +664,6 @@ class AsyncHttpClient:
             timeout=timeout,
         ) as stream:
             yield stream
+
+    async def aclose(self) -> None:
+        await self.httpx_client.aclose()


### PR DESCRIPTION
## What

`CambAI` and `AsyncCambAI` created an `httpx` client on construction but never exposed a way to close it — the underlying client is left open (unclosed connections/fds) unless users reach into internals.

Adds:

```python
with CambAI(api_key="...") as client:
    client.text_to_speech.tts(...)
# httpx client closed here

async with AsyncCambAI(api_key="...") as client:
    ...
# httpx async client closed here
```

## Implementation

- `camb/client.py`: `__enter__`/`__exit__` on `CambAI`, `__aenter__`/`__aexit__` on `AsyncCambAI`
- `camb/core/http_client.py`: `close()` on `HttpClient` and `aclose()` on `AsyncHttpClient` (thin delegation to the wrapped httpx client)

Exceptions propagate normally (`__exit__` does not suppress); close still runs on the exception path.

Note: a user-supplied custom `httpx_client` is also closed on exit — caller retains ownership concerns are the same as with `httpx.Client` context managers.

Verified: `is_closed` flips to `True` after exiting both `with` and `async with`.