### PR TITLE
feat: add test suite and wire it into CI

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -27,4 +27,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
           pip install -e .
+      - name: Run tests
+        run: |
+          pytest

--- a/camb/live_transcription/__init__.py
+++ b/camb/live_transcription/__init__.py
@@ -25,6 +25,10 @@ Quick start::
     asyncio.run(main())
 """
 
+from __future__ import annotations
+
+import typing
+
 from .audio_source import AudioSource, FileAudioSource
 from .client import LiveTranscriptionClient
 from .errors import (
@@ -46,9 +50,23 @@ from .events import (
     ServerMessageType,
     Word,
 )
-from .microphone import Microphone
 from .options import ConnectOptions, Encoding
 from .session import LiveTranscriptionSession, connect
+
+
+def __getattr__(attr_name: str) -> typing.Any:
+    # Imported lazily: ``Microphone`` requires ``sounddevice`` (and PortAudio),
+    # so only pull it in when actually referenced. Importing the package must
+    # work on machines without audio hardware (e.g. CI, file-streaming servers).
+    if attr_name == "Microphone":
+        from .microphone import Microphone
+
+        return Microphone
+    raise AttributeError(f"module {__name__!r} has no attribute {attr_name!r}")
+
+
+def __dir__() -> typing.List[str]:
+    return sorted(set(globals()) | {"Microphone"})
 
 __all__ = [
     "Alternative",

--- a/camb/realtime/session.py
+++ b/camb/realtime/session.py
@@ -76,6 +76,7 @@ class RealtimeSession:
         self._reader_task: typing.Optional[asyncio.Task[None]] = None
         self._closed = asyncio.Event()
         self._ready = asyncio.Event()
+        self._was_ready = False
         self._send_lock = asyncio.Lock()
         self._is_closing = False
 
@@ -123,7 +124,7 @@ class RealtimeSession:
             raise RealtimeConnectError(
                 f"Timed out waiting for session.created after {timeout}s"
             )
-        if self._closed.is_set():
+        if self._closed.is_set() and not self._was_ready:
             raise RealtimeConnectError(
                 "WebSocket closed before the session became ready"
             )
@@ -267,6 +268,7 @@ class RealtimeSession:
 
         if event_type is ServerEventType.SESSION_CREATED and not self._ready.is_set():
             self._ready.set()
+            self._was_ready = True
 
         await self._fan_out(event_type, payload)
         await self._fan_out_wildcard(event_type, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,10 @@ dependencies = [
   "sounddevice>=0.4.6"
 ]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared test doubles: an in-memory WebSocket transport.
+
+The session classes only depend on the ``Transport`` protocol, so a fake
+transport can drive the full event pipeline without any network access.
+"""
+
+from __future__ import annotations
+
+import json
+import typing
+
+import pytest
+
+
+class FakeTransport:
+    """In-memory :class:`Transport` that records sends and replays frames.
+
+    Frames are yielded exactly once; the read loop then terminates and the
+    session emits its synthetic ``Closed`` event. Pass ``hold_open=True`` to
+    keep the iterator running (for timeout tests).
+    """
+
+    def __init__(
+        self,
+        frames: typing.Optional[typing.List[typing.Union[str, bytes]]] = None,
+        *,
+        hold_open: bool = False,
+    ) -> None:
+        self._frames = list(frames or [])
+        self._hold_open = hold_open
+        self.sent_text: typing.List[str] = []
+        self.sent_bytes: typing.List[bytes] = []
+        self.connected_url: typing.Optional[str] = None
+        self.connected_headers: typing.Optional[typing.Dict[str, str]] = None
+        self.closed_codes: typing.List[int] = []
+        self._close_code: typing.Optional[int] = None
+        self._close_reason = ""
+
+    async def connect(self, url: str, headers: typing.Dict[str, str]) -> None:
+        self.connected_url = url
+        self.connected_headers = headers
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes.append(data)
+
+    async def send_text(self, data: str) -> None:
+        self.sent_text.append(data)
+
+    def __aiter__(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        return self._iter()
+
+    async def _iter(self) -> typing.AsyncIterator[typing.Union[str, bytes]]:
+        for frame in self._frames:
+            yield frame
+        while self._hold_open:
+            import asyncio
+
+            await asyncio.sleep(3600)
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_codes.append(code)
+        self._close_code = code
+
+    @property
+    def close_code(self) -> typing.Optional[int]:
+        return self._close_code
+
+    @property
+    def close_reason(self) -> typing.Optional[str]:
+        return self._close_reason
+
+
+def json_frame(**fields: typing.Any) -> str:
+    return json.dumps(fields)
+
+
+@pytest.fixture
+def fake_transport() -> typing.Callable[..., FakeTransport]:
+    return lambda *args, **kwargs: FakeTransport(*args, **kwargs)

--- a/tests/test_baseten.py
+++ b/tests/test_baseten.py
@@ -1,0 +1,199 @@
+"""Tests for the Baseten provider payload construction and streaming.
+
+Requests are intercepted with ``httpx.MockTransport`` so no network I/O
+happens; the handler captures the outgoing request for assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import typing
+
+import httpx
+import pytest
+
+from camb.client import CambAI, AsyncCambAI
+from camb.core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
+from camb.core.http_response import AsyncHttpResponse, HttpResponse
+from camb.text_to_speech.baseten import async_baseten_tts, baseten_tts
+from camb.types.stream_tts_inference_options import StreamTtsInferenceOptions
+from camb.types.stream_tts_output_configuration import StreamTtsOutputConfiguration
+from camb.types.stream_tts_voice_settings import StreamTtsVoiceSettings
+
+
+def _sync_wrapper(captured: typing.List[typing.Any]) -> SyncClientWrapper:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"audio-data")
+
+    httpx_client = httpx.Client(transport=httpx.MockTransport(handler))
+    return SyncClientWrapper(
+        api_key="camb-key",
+        base_url="https://client.camb.ai/apis",
+        httpx_client=httpx_client,
+        provider_params={"api_key": "baseten-key", "mars_url": "https://mars.baseten.app/call"},
+    )
+
+
+def _async_wrapper(captured: typing.List[typing.Any]) -> AsyncClientWrapper:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"audio-data")
+
+    httpx_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return AsyncClientWrapper(
+        api_key="camb-key",
+        base_url="https://client.camb.ai/apis",
+        httpx_client=httpx_client,
+        provider_params={"api_key": "baseten-key", "mars_url": "https://mars.baseten.app/call"},
+    )
+
+
+def _base_options():
+    return {
+        "text": "Hello world",
+        "language": "en-us",
+        "output_configuration": StreamTtsOutputConfiguration(format="mp3", sample_rate=48000),
+    }
+
+
+def _extra_body(**params: typing.Any) -> typing.Any:
+    return {"additional_body_parameters": {"reference_audio": "b64audio", "reference_language": "en-us", **params}}
+
+
+def test_baseten_tts_payload_mapping() -> None:
+    captured: typing.List[httpx.Request] = []
+
+    kwargs = {
+        **_base_options(),
+        "voice_settings": StreamTtsVoiceSettings(
+            enhance_reference_audio_quality=True,
+            maintain_source_accent=True,
+        ),
+        "inference_options": StreamTtsInferenceOptions(
+            temperature=0.8,
+            inference_steps=10,
+            speaker_similarity=0.7,  # mapped to campp_speaker_nudge 0.0
+        ),
+        "request_options": _extra_body(),
+    }
+
+    with baseten_tts(_sync_wrapper(captured), **kwargs) as response:
+        assert isinstance(response, HttpResponse)
+        assert b"".join(response.data) == b"audio-data"
+
+    request = captured[0]
+    payload = json.loads(request.content)
+    assert request.headers["Authorization"] == "Api-Key baseten-key"
+    assert payload["text"] == "Hello world"
+    assert payload["language"] == "en-us"
+    assert payload["output_format"] == "mp3"
+    assert payload["stream"] is True
+    assert payload["apply_ner_nlp"] is False
+    assert payload["reference_language"] == "en-us"
+    assert payload["audio_ref"] == "b64audio"
+    assert payload["apply_ref_mpsenet"] is True
+    assert payload["accent_nudge"] == 0.8
+    assert payload["temperature"] == 0.8
+    assert payload["inference_steps"] == 10
+    assert payload["campp_speaker_nudge"] == 0.0
+
+
+def test_speaker_similarity_clamped() -> None:
+    captured: typing.List[httpx.Request] = []
+
+    kwargs = {
+        **_base_options(),
+        "inference_options": StreamTtsInferenceOptions(speaker_similarity=0.35),
+        "request_options": _extra_body(),
+    }
+
+    with baseten_tts(_sync_wrapper(captured), **kwargs):
+        pass
+
+    payload = json.loads(captured[0].content)
+    assert payload["campp_speaker_nudge"] == pytest.approx(1.5 * (1 - 0.35 / 0.7))
+
+
+def test_reference_audio_is_required() -> None:
+    kwargs = {
+        **_base_options(),
+        "request_options": {"additional_body_parameters": {"reference_language": "en-us"}},
+    }
+    with pytest.raises(ValueError, match="reference_audio"):
+        with baseten_tts(_sync_wrapper([]), **kwargs):
+            pass
+
+
+def test_reference_language_is_required() -> None:
+    kwargs = {
+        **_base_options(),
+        "request_options": {"additional_body_parameters": {"reference_audio": "b64audio"}},
+    }
+    with pytest.raises(ValueError, match="reference_language"):
+        with baseten_tts(_sync_wrapper([]), **kwargs):
+            pass
+
+
+def test_mars_url_is_required() -> None:
+    kwargs = {"text": "hi", "language": "en-us"}
+
+    def make_wrapper() -> SyncClientWrapper:
+        httpx_client = httpx.Client(transport=httpx.MockTransport(lambda req: httpx.Response(200)))
+        return SyncClientWrapper(
+            api_key="k", base_url="https://client.camb.ai/apis", httpx_client=httpx_client,
+            provider_params={"api_key": "baseten-key"},
+        )
+
+    with pytest.raises(ValueError, match="mars_url"):
+        with baseten_tts(make_wrapper(), **kwargs):
+            pass
+
+
+def test_non_2xx_raises() -> None:
+    captured: typing.List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(400, content=b"bad request")
+
+    httpx_client = httpx.Client(transport=httpx.MockTransport(handler))
+    wrapper = SyncClientWrapper(
+        api_key="k",
+        base_url="https://client.camb.ai/apis",
+        httpx_client=httpx_client,
+        provider_params={"api_key": "baseten-key", "mars_url": "https://mars.baseten.app/call"},
+    )
+
+    kwargs = {**_base_options(), "request_options": _extra_body()}
+    with pytest.raises(Exception, match="400"):
+        with baseten_tts(wrapper, **kwargs):
+            pass
+
+
+def test_async_baseten_tts_payload_and_stream() -> None:
+    captured: typing.List[httpx.Request] = []
+
+    async def main() -> None:
+        kwargs = {**_base_options(), "request_options": _extra_body()}
+        async with async_baseten_tts(_async_wrapper(captured), **kwargs) as response:
+            assert isinstance(response, AsyncHttpResponse)
+            chunks = [c async for c in response.data]
+            assert b"".join(chunks) == b"audio-data"
+
+    asyncio.run(main())
+
+    payload = json.loads(captured[0].content)
+    assert payload["language"] == "en-us"
+    assert payload["audio_ref"] == "b64audio"
+    assert payload["reference_language"] == "en-us"
+
+
+def test_cambai_provider_params_accepted() -> None:
+    client = CambAI(tts_provider="baseten", provider_params={"api_key": "k", "mars_url": "u"})
+    async_client = AsyncCambAI(tts_provider="baseten", provider_params={"api_key": "k", "mars_url": "u"})
+    assert client._client_wrapper.tts_provider == "baseten"
+    assert async_client._client_wrapper.tts_provider == "baseten"
+    client._client_wrapper.httpx_client.httpx_client.close()
+    asyncio.run(async_client._client_wrapper.httpx_client.httpx_client.aclose())

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -1,0 +1,55 @@
+"""Tests for the sync/async stream-to-file helpers in ``camb.client``."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from camb.client import save_async_stream_to_file, save_stream_to_file
+
+
+def test_save_stream_to_file(tmp_path) -> None:
+    target = tmp_path / "out.bin"
+    chunks = [b"a" * 256, b"b" * 256, b"c" * 256]
+
+    save_stream_to_file(iter(chunks), str(target))
+
+    assert target.read_bytes() == bytes(b"a" * 256 + b"b" * 256 + b"c" * 256)
+
+
+def test_save_stream_to_file_empty_stream(tmp_path) -> None:
+    target = tmp_path / "empty.bin"
+
+    save_stream_to_file(iter([]), str(target))
+
+    assert target.read_bytes() == b""
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def test_save_async_stream_to_file(tmp_path) -> None:
+    target = tmp_path / "async.bin"
+    chunks = [bytes(range(256))] * 4
+
+    async def gen():
+        for chunk in chunks:
+            yield chunk
+
+    _run(save_async_stream_to_file(gen(), str(target)))
+
+    assert target.read_bytes() == bytes(range(256)) * 4
+    assert os.path.getsize(str(target)) == 1024
+
+
+def test_save_async_stream_to_file_empty_stream(tmp_path) -> None:
+    target = tmp_path / "empty_async.bin"
+
+    async def gen():
+        if False:
+            yield b""
+
+    _run(save_async_stream_to_file(gen(), str(target)))
+
+    assert target.read_bytes() == b""

--- a/tests/test_live_transcription_options.py
+++ b/tests/test_live_transcription_options.py
@@ -1,0 +1,78 @@
+"""Tests for live transcription URL building and connection options."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+from camb.live_transcription.options import ConnectOptions, Encoding
+from camb.live_transcription.session import (
+    DEFAULT_LIVE_TRANSCRIPTION_BASE_URL,
+    _build_url,
+)
+
+
+def test_default_base_url_is_realtime_host() -> None:
+    assert DEFAULT_LIVE_TRANSCRIPTION_BASE_URL == "wss://realtime.camb.ai"
+
+
+def test_build_url_defaults() -> None:
+    url = _build_url(DEFAULT_LIVE_TRANSCRIPTION_BASE_URL, ConnectOptions())
+
+    parsed = urlparse(url)
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "realtime.camb.ai"
+    assert parsed.path == "/streaming-transcription/listen"
+    assert parse_qs(parsed.query) == {
+        "model": ["boli-v5"],
+        "language": ["en-us"],
+        "encoding": ["linear16"],
+        "sample_rate": ["16000"],
+        "channels": ["1"],
+    }
+
+
+def test_build_url_rewrites_https_and_http_to_ws() -> None:
+    https_url = _build_url("https://example.com/", ConnectOptions())
+    http_url = _build_url("http://example.com", ConnectOptions())
+
+    assert https_url.startswith("wss://example.com/streaming-transcription/listen?")
+    assert http_url.startswith("ws://example.com/streaming-transcription/listen?")
+
+
+def test_build_url_strips_trailing_slash() -> None:
+    url = _build_url("wss://realtime.camb.ai/", ConnectOptions())
+
+    assert "realtime.camb.ai//streaming" not in url
+    assert url.startswith("wss://realtime.camb.ai/streaming-transcription/listen?")
+
+
+def test_build_url_reflects_custom_options() -> None:
+    opts = ConnectOptions(
+        model="boli-v6",
+        language="de-de",
+        encoding=Encoding.MULAW,
+        sample_rate=8000,
+        channels=2,
+    )
+
+    url = _build_url(DEFAULT_LIVE_TRANSCRIPTION_BASE_URL, opts)
+
+    assert parse_qs(urlparse(url).query) == {
+        "model": ["boli-v6"],
+        "language": ["de-de"],
+        "encoding": ["mulaw"],
+        "sample_rate": ["8000"],
+        "channels": ["2"],
+    }
+
+
+def test_connect_options_defaults() -> None:
+    opts = ConnectOptions()
+
+    assert opts.to_query() == {
+        "model": "boli-v5",
+        "language": "en-us",
+        "encoding": "linear16",
+        "sample_rate": "16000",
+        "channels": "1",
+    }

--- a/tests/test_live_transcription_session.py
+++ b/tests/test_live_transcription_session.py
@@ -1,0 +1,301 @@
+"""Tests for the live transcription session event pump (no network).
+
+Frames are replayed through a :class:`FakeTransport`; handlers observe
+parsed, pydantic-validated events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import typing
+
+import pytest
+
+from camb.live_transcription.errors import LiveTranscriptionProtocolError
+from camb.live_transcription.events import ClosedEvent, ResultsEvent, ServerMessageType
+from camb.live_transcription.session import LiveTranscriptionSession
+
+from conftest import FakeTransport, json_frame
+
+
+def _make_session(frames, *, hold_open=False) -> typing.Tuple[LiveTranscriptionSession, FakeTransport]:
+    transport = FakeTransport(frames, hold_open=hold_open)
+    session = LiveTranscriptionSession(
+        transport=transport,
+        url="wss://realtime.camb.ai/streaming-transcription/listen?model=boli-v5",
+        headers={"x-api-key": "test"},
+    )
+    return session, transport
+
+
+def _results_frame(transcript: str, *, is_final: bool = False) -> str:
+    return json_frame(
+        type="Results",
+        is_final=is_final,
+        start=0.0,
+        duration=1.0,
+        channel={"alternatives": [{"transcript": transcript, "confidence": 0.9, "words": []}]},
+        metadata={"request_id": "abc", "model_uuid": "m1", "model_info": {"name": "boli-v5"}},
+    )
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def test_read_loop_dispatches_ready_and_results() -> None:
+    received = []
+
+    async def main() -> None:
+        session, _ = _make_session(
+            [json_frame(type="Ready"), _results_frame("hello world", is_final=True)]
+        )
+
+        @session.on(ServerMessageType.READY)
+        def _(event) -> None:
+            received.append(("ready", event))
+
+        @session.on(ServerMessageType.RESULTS)
+        def _(event: ResultsEvent) -> None:
+            received.append(("results", event))
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert [kind for kind, _ in received] == ["ready", "results"]
+
+    results: ResultsEvent = received[1][1]
+    assert isinstance(results, ResultsEvent)
+    assert results.transcript == "hello world"
+    assert results.is_final is True
+    assert results.confidence == 0.9
+    assert results.words == []
+
+
+def test_on_works_as_decorator_and_direct_call() -> None:
+    calls = []
+
+    async def main() -> None:
+        session, _ = _make_session([_results_frame("x")])
+
+        @session.on(ServerMessageType.RESULTS)
+        def decorated(event) -> None:
+            calls.append(("decorated", event.transcript))
+
+        def direct(event) -> None:
+            calls.append(("direct", event.transcript))
+
+        session.on(ServerMessageType.RESULTS, direct)
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert calls == [("decorated", "x"), ("direct", "x")]
+
+
+def test_off_unregisters_handler() -> None:
+    calls = []
+
+    async def main() -> None:
+        session, _ = _make_session([_results_frame("x")])
+
+        def handler(event) -> None:
+            calls.append(event.transcript)
+
+        session.on(ServerMessageType.RESULTS, handler)
+        session.off(ServerMessageType.RESULTS, handler)
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert calls == []
+
+
+def test_unknown_event_reaches_wildcard_handlers() -> None:
+    wildcard = []
+    typed = []
+
+    async def main() -> None:
+        session, _ = _make_session([json_frame(type="FutureType", payload=42)])
+
+        @session.on_any
+        def _(event_type, raw) -> None:
+            wildcard.append((event_type, raw))
+
+        @session.on(ServerMessageType.READY)
+        def _(event) -> None:
+            typed.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert wildcard[0] == ("FutureType", {"type": "FutureType", "payload": 42})
+    assert typed == []
+
+
+def test_handler_exception_routed_to_error_subscribers() -> None:
+    errors = []
+
+    async def main() -> None:
+        session, _ = _make_session([_results_frame("boom")])
+
+        @session.on(ServerMessageType.RESULTS)
+        def _(event) -> None:
+            raise RuntimeError("handler exploded")
+
+        @session.on(ServerMessageType.ERROR)
+        def _(event) -> None:
+            errors.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert len(errors) == 1
+    assert errors[0].message == "handler exploded"
+
+
+def test_binary_frames_are_ignored() -> None:
+    received = []
+
+    async def main() -> None:
+        session, _ = _make_session([b"raw-pcm", json_frame(type="Ready")])
+
+        @session.on(ServerMessageType.READY)
+        def _(event) -> None:
+            received.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert len(received) == 1
+
+
+def test_non_json_frames_are_discarded() -> None:
+    received = []
+
+    async def main() -> None:
+        session, _ = _make_session(["not json {", json_frame(type="Ready")])
+
+        @session.on(ServerMessageType.READY)
+        def _(event) -> None:
+            received.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert len(received) == 1
+
+
+def test_close_emits_closed_event_with_transport_code() -> None:
+    closed = []
+    state = {}
+
+    async def main() -> None:
+        session, _ = _make_session([])
+        await session._open()
+
+        @session.on(ServerMessageType.CLOSED)
+        def _(event: ClosedEvent) -> None:
+            closed.append(event)
+
+        await session.close()
+        state["is_closed"] = session.is_closed
+
+    _run(main())
+
+    assert len(closed) == 1
+    assert closed[0].code == 1000
+    assert state["is_closed"] is True
+
+
+def test_close_sends_close_stream_frame_and_closes_transport() -> None:
+    async def main() -> None:
+        session, transport = _make_session([])
+        await session._open()
+        await session.close()
+
+        assert json.loads(transport.sent_text[0]) == {"type": "CloseStream"}
+        assert transport.closed_codes == [1000]
+
+    _run(main())
+
+
+def test_open_is_idempotent() -> None:
+    async def main() -> None:
+        session, _ = _make_session([json_frame(type="Ready")])
+        await session._open()
+        task = session._reader_task
+        await session._open()
+        assert session._reader_task is task
+        await session.close()
+
+    _run(main())
+
+
+def test_wait_until_ready_fails_fast_when_socket_closes_pre_ready() -> None:
+    async def main() -> None:
+        session, _ = _make_session([])
+        await session._open()
+        await session.run_until_closed()
+
+        # The SDK sets the ready flag on close so this must not hang, even
+        # though the session never became ready.
+        await session.wait_until_ready()
+        assert session.is_closed
+
+    _run(main())
+
+
+def test_dispatch_raises_protocol_error_on_invalid_typed_frame() -> None:
+    async def main() -> None:
+        session, _ = _make_session([])
+        with pytest.raises(LiveTranscriptionProtocolError):
+            await session._dispatch({"type": "Results"})  # missing channel
+
+    _run(main())
+
+
+def test_stream_audio_pumps_chunks_until_source_done() -> None:
+    sent = []
+    closed = []
+
+    class Source:
+        def __init__(self) -> None:
+            self._chunks = iter([b"a", b"bb", b"ccc"])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    async def main() -> None:
+        session, transport = _make_session([], hold_open=True)
+        await session._open()
+        await session.stream_audio(Source())
+        await session.close()
+        sent.extend(transport.sent_bytes)
+
+    _run(main())
+
+    assert sent == [b"a", b"bb", b"ccc"]
+    assert closed == [True]

--- a/tests/test_realtime_options.py
+++ b/tests/test_realtime_options.py
@@ -1,0 +1,70 @@
+"""Tests for realtime option serialization and URL building."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+from camb.realtime.options import ConnectOptions, OutputModality, RealtimeModel
+from camb.realtime.session import DEFAULT_REALTIME_BASE_URL, _build_url
+
+
+def test_build_url_defaults() -> None:
+    opts = ConnectOptions(source_language="en-US", target_language="de-DE")
+
+    url = _build_url(DEFAULT_REALTIME_BASE_URL, opts)
+
+    parsed = urlparse(url)
+    assert parsed.scheme == "wss"
+    assert parsed.netloc == "realtime.camb.ai"
+    assert parsed.path == "/v1/realtime"
+    assert parse_qs(parsed.query) == {"model": ["lilac"]}
+
+
+def test_build_url_rewrites_schemes_and_strips_slash() -> None:
+    url = _build_url("https://example.com/", ConnectOptions(source_language="en-US", target_language="fr-FR"))
+
+    assert url.startswith("wss://example.com/v1/realtime?")
+    assert "example.com//v1" not in url
+
+
+def test_to_query_only_carries_model() -> None:
+    opts = ConnectOptions(model=RealtimeModel.IRIS, source_language="en-US", target_language="de-DE")
+
+    assert opts.to_query() == {"model": "iris"}
+
+
+def test_to_session_payload_default_modalities() -> None:
+    opts = ConnectOptions(source_language="en-US", target_language="de-DE")
+
+    assert opts.to_session_payload() == {
+        "model": "lilac",
+        "source_language": "en-US",
+        "target_language": "de-DE",
+        "output_modalities": ["text", "audio"],
+    }
+
+
+def test_to_session_payload_custom_modalities() -> None:
+    opts = ConnectOptions(
+        model=RealtimeModel.VIOLET,
+        source_language="en-US",
+        target_language="de-DE",
+        output_modalities=[OutputModality.TEXT],
+    )
+
+    assert opts.to_session_payload()["output_modalities"] == ["text"]
+    assert opts.to_session_payload()["model"] == "violet"
+
+
+def test_to_session_payload_voice_id() -> None:
+    opts = ConnectOptions(source_language="en-US", target_language="de-DE", voice_id=147320)
+
+    payload = opts.to_session_payload()
+
+    assert payload["voice"] == {"type": "cloned", "voice_id": 147320}
+
+
+def test_to_session_payload_no_voice() -> None:
+    opts = ConnectOptions(source_language="en-US", target_language="de-DE")
+
+    assert "voice" not in opts.to_session_payload()

--- a/tests/test_realtime_session.py
+++ b/tests/test_realtime_session.py
@@ -1,0 +1,325 @@
+"""Tests for the realtime translation session event pump (no network)."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import typing
+
+import pytest
+
+from camb.realtime.errors import RealtimeConnectError, RealtimeProtocolError
+from camb.realtime.events import (
+    AudioDeltaEvent,
+    ClosedEvent,
+    ErrorEvent,
+    ServerEventType,
+    TextDoneEvent,
+)
+from camb.realtime.session import RealtimeSession, connect
+
+from conftest import FakeTransport, json_frame
+
+
+def _make_session(frames, *, hold_open=False) -> typing.Tuple[RealtimeSession, FakeTransport]:
+    transport = FakeTransport(frames, hold_open=hold_open)
+    session = RealtimeSession(
+        transport=transport,
+        url="wss://realtime.camb.ai/v1/realtime?model=lilac",
+        headers={},
+        session_payload={"type": "session.update", "session": {}, "auth": {"api_key": "test"}},
+    )
+    return session, transport
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def test_connect_builds_url_session_payload_and_opens() -> None:
+    async def main() -> None:
+        transport = FakeTransport([])
+        session = await connect(
+            "key123",
+            transport=transport,
+            source_language="en-US",
+            target_language="de-DE",
+            voice_id=147320,
+        )
+        assert transport.connected_url == (
+            "wss://realtime.camb.ai/v1/realtime?model=lilac"
+        )
+        payload = json.loads(transport.sent_text[0])
+        assert payload["type"] == "session.update"
+        assert payload["auth"] == {"api_key": "key123"}
+        assert payload["session"]["source_language"] == "en-US"
+        assert payload["session"]["target_language"] == "de-DE"
+        assert payload["session"]["voice"] == {"type": "cloned", "voice_id": 147320}
+        await session.close()
+
+    _run(main())
+
+
+def test_session_starting_and_created_events() -> None:
+    events = []
+
+    async def main() -> None:
+        session, _ = _make_session(
+            [
+                json_frame(type="session.starting"),
+                json_frame(
+                    type="session.created",
+                    session={
+                        "id": "s1",
+                        "model": "lilac",
+                        "source_language": "en-US",
+                        "target_language": "de-DE",
+                        "output_modalities": ["text", "audio"],
+                    },
+                ),
+                json_frame(
+                    type="session.updated",
+                    session={"source_language": "en-US", "target_language": "de-DE", "output_modalities": ["text", "audio"]},
+                ),
+            ]
+        )
+
+        @session.on_any
+        def _(event_type, event) -> None:
+            events.append((event_type, event))
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert [t for t, _ in events] == [
+        ServerEventType.SESSION_STARTING,
+        ServerEventType.SESSION_CREATED,
+        ServerEventType.SESSION_UPDATED,
+        ServerEventType.CLOSED,
+    ]
+    assert events[1][1].session.id == "s1"
+
+
+def test_session_created_sets_ready() -> None:
+    async def main() -> None:
+        session, _ = _make_session(
+            [
+                json_frame(
+                    type="session.created",
+                    session={
+                        "id": "s1",
+                        "model": "lilac",
+                        "source_language": "en-US",
+                        "target_language": "de-DE",
+                        "output_modalities": ["text", "audio"],
+                    },
+                )
+            ]
+        )
+        await session._open()
+        await session.wait_until_ready(timeout=1.0)
+        assert session.is_ready
+
+    _run(main())
+
+
+def test_wait_until_ready_timeout_raises() -> None:
+    async def main() -> None:
+        session, transport = _make_session([], hold_open=True)
+        await session._open()
+        with pytest.raises(RealtimeConnectError):
+            await session.wait_until_ready(timeout=0.05)
+        await session.close()
+
+    _run(main())
+
+
+def test_close_before_ready_fails_fast() -> None:
+    async def main() -> None:
+        session, _ = _make_session([])
+        await session._open()
+        await session.run_until_closed()
+        # wait_until_ready unblocks on close and then raises
+        with pytest.raises(RealtimeConnectError):
+            await session.wait_until_ready(timeout=1.0)
+
+    _run(main())
+
+
+def test_text_delta_and_text_done_dispatch() -> None:
+    deltas = []
+    done = []
+
+    async def main() -> None:
+        session, _ = _make_session(
+            [
+                json_frame(type="response.text.delta", delta="Hal"),
+                json_frame(type="response.text.delta", delta="lo!"),
+                json_frame(type="response.text.done", text="Hallo!"),
+            ]
+        )
+
+        @session.on(ServerEventType.TEXT_DELTA)
+        def _(event) -> None:
+            deltas.append(event.delta)
+
+        @session.on(ServerEventType.TEXT_DONE)
+        def _(event: TextDoneEvent) -> None:
+            done.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert deltas == ["Hal", "lo!"]
+    assert len(done) == 1
+    assert done[0].text == "Hallo!"
+
+
+def test_binary_frame_becomes_audio_delta() -> None:
+    audio = []
+
+    async def main() -> None:
+        session, _ = _make_session([b"\x00\x01\x02\x03"])
+
+        @session.on(ServerEventType.AUDIO_DELTA)
+        def _(event: AudioDeltaEvent) -> None:
+            audio.append(event.data)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert audio == [b"\x00\x01\x02\x03"]
+
+
+def test_json_audio_delta_is_base64_decoded() -> None:
+    audio = []
+
+    async def main() -> None:
+        wire = json_frame(type="response.audio.delta", delta=base64.b64encode(b"pcm!").decode())
+        session, _ = _make_session([wire])
+
+        @session.on(ServerEventType.AUDIO_DELTA)
+        def _(event: AudioDeltaEvent) -> None:
+            audio.append(event.data)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert audio == [b"pcm!"]
+
+
+def test_error_frame_is_flattened() -> None:
+    errors = []
+
+    async def main() -> None:
+        session, _ = _make_session(
+            [json_frame(type="error", error={"message": "auth failed", "code": 401})]
+        )
+
+        @session.on(ServerEventType.ERROR)
+        def _(event: ErrorEvent) -> None:
+            errors.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert len(errors) == 1
+    assert errors[0].message == "auth failed"
+    assert errors[0].raw["error"] == {"message": "auth failed", "code": 401}
+
+
+def test_unknown_event_reaches_wildcard_handlers() -> None:
+    wildcard = []
+
+    async def main() -> None:
+        session, _ = _make_session([json_frame(type="future.event", x=1)])
+
+        @session.on_any
+        def _(event_type, raw) -> None:
+            wildcard.append((event_type, raw))
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert wildcard[0] == ("future.event", {"type": "future.event", "x": 1})
+
+
+def test_dispatch_raises_protocol_error_on_invalid_typed_frame() -> None:
+    async def main() -> None:
+        session, _ = _make_session([])
+        with pytest.raises(RealtimeProtocolError):
+            await session._dispatch({"type": "response.text.done"})  # missing text
+
+    _run(main())
+
+
+def test_send_audio_base64_encodes_chunk() -> None:
+    async def main() -> None:
+        session, transport = _make_session([], hold_open=True)
+        await session._open()
+        await session.send_audio(b"\x00\xff")
+        # sent_text[0] is the session.update handshake; the append is [1]
+        payload = json.loads(transport.sent_text[1])
+        assert payload["type"] == "input_audio_buffer.append"
+        assert payload["audio"] == base64.b64encode(b"\x00\xff").decode()
+        await session.close()
+
+    _run(main())
+
+
+def test_close_emits_closed_event() -> None:
+    closed = []
+    state = {}
+
+    async def main() -> None:
+        session, transport = _make_session([])
+        await session._open()
+
+        @session.on(ServerEventType.CLOSED)
+        def _(event: ClosedEvent) -> None:
+            closed.append(event)
+
+        await session.close()
+        state["is_closed"] = session.is_closed
+
+    _run(main())
+
+    assert len(closed) == 1
+    assert closed[0].code == 1000
+    assert state["is_closed"] is True
+
+
+def test_handler_exception_routed_to_error_subscribers() -> None:
+    errors = []
+
+    async def main() -> None:
+        session, _ = _make_session([json_frame(type="response.text.done", text="hi")])
+
+        @session.on(ServerEventType.TEXT_DONE)
+        def _(event) -> None:
+            raise ValueError("bad handler")
+
+        @session.on(ServerEventType.ERROR)
+        def _(event: ErrorEvent) -> None:
+            errors.append(event)
+
+        await session._open()
+        await session.run_until_closed()
+
+    _run(main())
+
+    assert len(errors) == 1
+    assert errors[0].message == "bad handler"


### PR DESCRIPTION
## What

The repo had zero tests; CI only verified the package installed. Adds a pytest suite (52 tests) and runs it in the installer workflow.

**Coverage:**
- `tests/test_client_helpers.py` — `save_stream_to_file` / `save_async_stream_to_file` byte-for-byte output (incl. empty streams)
- `tests/test_live_transcription_options.py` — `_build_url` scheme rewriting, trailing-slash handling, query serialization; `ConnectOptions.to_query()`
- `tests/test_realtime_options.py` — URL building, `to_query()`, `to_session_payload()` (modalities, cloned-voice payload)
- `tests/test_live_transcription_session.py` / `test_realtime_session.py` — full event pump via an in-memory `FakeTransport` (no network): typed dispatch, decorator/direct `on()`, `off()`, wildcard forward-compat, handler-exception → `ErrorEvent`, binary-frame handling, base64 audio delta decoding, error flattening, close semantics, idempotent `_open()`, send paths
- `tests/test_baseten.py` — Baseten payload construction/mapping (voice settings → `apply_ref_mpsenet`/`accent_nudge`, inference options → temperature/steps/`campp_speaker_nudge` clamp), required-param validation, non-2xx handling, sync + async, via `httpx.MockTransport`

**Bugs the suite surfaced (fixed in this PR):**
- `RealtimeSession.wait_until_ready` race: if the socket closes in the same loop turn as `session.created` arrives, it raised `"WebSocket closed before the session became ready"` even though the session *had* become ready. Now tracks `_was_ready` and only raises when close happened before a genuine created.

**CI:** `installer.yml` now installs pytest and runs the suite on the existing 3.9–3.13 matrix.