### PR TITLE
feat: add polling helpers for async task workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,27 @@ The Camb AI SDK offers a wide range of capabilities beyond these examples, inclu
 
 Please refer to [examples](examples/) for direct runnable examples and Official Camb AI API Documentation for a comprehensive list of features and advanced usage patterns.
 
+### Polling task status
+
+Long-running workflows (dubbing, transcription, subtitles, text-to-audio)
+expose their progress through a status endpoint returning
+`SUCCESS` / `PENDING` / `ERROR`. Instead of hand-writing the polling loop,
+use the helpers in `camb.polling`:
+
+```python
+from camb.polling import PollTimeoutError, poll_dubbing
+
+status = poll_dubbing(client.dub, task_id=task_id, interval=5, timeout=600)
+result = client.dub.get_dubbed_run_info(status.run_id)
+```
+
+- `poll_dubbing(client.dub, task_id, ...)` / `poll_transcription(client.transcription, ...)` /
+  `poll_subtitle(client.subtitles, ...)` / `poll_text_to_audio(client.text_to_audio, ...)`
+- Async equivalents `apoll_*` for the `Async*` clients
+- `status` is the `SUCCESS` status object; use `status.run_id` to fetch the result
+- Raises `PollFailureError` immediately if the task reports `ERROR`, and
+  `PollTimeoutError` if it does not succeed within `timeout` (`None` polls forever)
+
 ## 📖 Examples
 
 Check out the `examples/` directory for complete, runnable examples:

--- a/camb/polling.py
+++ b/camb/polling.py
@@ -1,0 +1,164 @@
+"""Polling helpers for async task workflows.
+
+Long-running workflows (dubbing, transcription, subtitles, text-to-audio)
+create a task and require repeated status checks until ``SUCCESS``. These
+helpers remove the hand-written loop::
+
+    from camb.polling import poll_dubbing
+
+    status = poll_dubbing(client.dub, task_id=task_id, timeout=600)
+    result = client.dub.get_dubbed_run_info(status.run_id)
+
+Three states exist: ``SUCCESS``, ``PENDING`` and ``ERROR`` (see
+``camb.types.TaskStatus``). Polling stops as soon as a terminal state is
+seen; an ``ERROR`` status raises immediately, and a missing ``SUCCESS``
+before ``timeout`` raises :class:`PollTimeoutError`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import typing
+
+SUCCESS = "SUCCESS"
+PENDING = "PENDING"
+ERROR = "ERROR"
+
+Status = typing.Any  # any object with .status (TaskStatus) and .run_id
+
+
+class PollError(Exception):
+    """Base class for every exception raised by ``camb.polling``."""
+
+
+class PollTimeoutError(PollError):
+    """The task did not reach a terminal state within the deadline."""
+
+
+class PollFailureError(PollError):
+    """The task reported an ``ERROR`` status."""
+
+
+def poll_until_complete(
+    get_status: typing.Callable[[], Status],
+    *,
+    interval: float = 5.0,
+    timeout: typing.Optional[float] = None,
+) -> Status:
+    """Poll ``get_status`` until it reports ``SUCCESS``.
+
+    Parameters
+    ----------
+    get_status : typing.Callable[[], Status]
+        A zero-argument callable returning a status object with ``status``
+        and ``run_id`` attributes (e.g. ``lambda: client.dub.get_dubbing_status(task_id=...)``).
+    interval : float
+        Seconds to wait between status checks (default 5).
+    timeout : typing.Optional[float]
+        Total seconds allowed before raising :class:`PollTimeoutError`.
+        ``None`` (default) polls indefinitely.
+
+    Returns
+    -------
+    Status
+        The status object that reported ``SUCCESS`` (carries ``run_id``).
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while True:
+        status = get_status()
+        if status.status == SUCCESS:
+            return status
+        _check_terminal(status)
+        if deadline is not None and time.monotonic() >= deadline:
+            raise PollTimeoutError(f"Task did not complete within {timeout}s")
+        time.sleep(interval)
+
+
+async def apoll_until_complete(
+    aget_status: typing.Callable[[], typing.Awaitable[Status]],
+    *,
+    interval: float = 5.0,
+    timeout: typing.Optional[float] = None,
+) -> Status:
+    """Async equivalent of :func:`poll_until_complete` for ``Async*Client``s."""
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while True:
+        status = await aget_status()
+        if status.status == SUCCESS:
+            return status
+        _check_terminal(status)
+        if deadline is not None and time.monotonic() >= deadline:
+            raise PollTimeoutError(f"Task did not complete within {timeout}s")
+        await asyncio.sleep(interval)
+
+
+def _check_terminal(status: Status) -> None:
+    if status.status == ERROR:
+        reason = getattr(status, "message", None) or getattr(status, "exception_reason", None) or ""
+        details = f": {reason}" if reason else ""
+        raise PollFailureError(f"Task ended with ERROR status{details}")
+
+
+def poll_dubbing(dub_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    """Poll ``dub_client.get_dubbing_status`` until complete.
+
+    Fetch the final outputs with ``dub_client.get_dubbed_run_info(status.run_id)``.
+    """
+    return poll_until_complete(
+        lambda: dub_client.get_dubbing_status(task_id=task_id), **kwargs
+    )
+
+
+async def apoll_dubbing(dub_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    return await apoll_until_complete(
+        lambda: dub_client.get_dubbing_status(task_id=task_id), **kwargs
+    )
+
+
+def poll_transcription(transcription_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    """Poll ``transcription_client.get_transcription_task_status`` until complete.
+
+    Fetch the final output with ``transcription_client.get_transcription_result(status.run_id)``.
+    """
+    return poll_until_complete(
+        lambda: transcription_client.get_transcription_task_status(task_id=task_id), **kwargs
+    )
+
+
+async def apoll_transcription(transcription_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    return await apoll_until_complete(
+        lambda: transcription_client.get_transcription_task_status(task_id=task_id), **kwargs
+    )
+
+
+def poll_subtitle(subtitles_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    """Poll ``subtitles_client.get_subtitle_task_status`` until complete.
+
+    Fetch the final output with ``subtitles_client.get_subtitle_result(status.run_id)``.
+    """
+    return poll_until_complete(
+        lambda: subtitles_client.get_subtitle_task_status(task_id=task_id), **kwargs
+    )
+
+
+async def apoll_subtitle(subtitles_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    return await apoll_until_complete(
+        lambda: subtitles_client.get_subtitle_task_status(task_id=task_id), **kwargs
+    )
+
+
+def poll_text_to_audio(text_to_audio_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    """Poll ``text_to_audio_client.get_text_to_audio_status`` until complete.
+
+    Fetch the final output with ``text_to_audio_client.get_text_to_audio_result(status.run_id)``.
+    """
+    return poll_until_complete(
+        lambda: text_to_audio_client.get_text_to_audio_status(task_id=task_id), **kwargs
+    )
+
+
+async def apoll_text_to_audio(text_to_audio_client: typing.Any, task_id: str, **kwargs: typing.Any) -> Status:
+    return await apoll_until_complete(
+        lambda: text_to_audio_client.get_text_to_audio_status(task_id=task_id), **kwargs
+    )

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,240 @@
+"""Tests for the polling helpers in ``camb.polling``."""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+
+import pytest
+
+from camb.polling import (
+    PollFailureError,
+    PollTimeoutError,
+    apoll_dubbing,
+    apoll_subtitle,
+    apoll_text_to_audio,
+    apoll_transcription,
+    apoll_until_complete,
+    poll_dubbing,
+    poll_subtitle,
+    poll_text_to_audio,
+    poll_transcription,
+    poll_until_complete,
+)
+
+
+class _FakeStatus:
+    def __init__(self, status: str, *, run_id: typing.Optional[int] = None, message: typing.Optional[str] = None) -> None:
+        self.status = status
+        self.run_id = run_id
+        self.message = message
+
+
+def _success() -> _FakeStatus:
+    return _FakeStatus("SUCCESS", run_id=7)
+
+
+def test_returns_immediately_on_success() -> None:
+    calls = []
+
+    def get_status() -> _FakeStatus:
+        calls.append(1)
+        return _success()
+
+    status = poll_until_complete(get_status, interval=0.001)
+
+    assert status.status == "SUCCESS"
+    assert status.run_id == 7
+    assert calls == [1]
+
+
+def test_polls_until_success() -> None:
+    statuses = iter(["PENDING", "PENDING", "SUCCESS"])
+
+    status = poll_until_complete(lambda: _FakeStatus(next(statuses), run_id=3), interval=0.001, timeout=10)
+
+    assert status.run_id == 3
+
+
+def test_pending_is_not_terminal() -> None:
+    statuses = iter(["PENDING", "SUCCESS"])
+
+    status = poll_until_complete(lambda: _FakeStatus(next(statuses)), interval=0.001, timeout=5)
+
+    assert status.status == "SUCCESS"
+
+
+def test_error_raises_immediately() -> None:
+    with pytest.raises(PollFailureError, match="ERROR"):
+        poll_until_complete(lambda: _FakeStatus("ERROR"), interval=0.001)
+
+
+def test_error_message_included() -> None:
+    with pytest.raises(PollFailureError, match="boom"):
+        poll_until_complete(
+            lambda: _FakeStatus("ERROR", message="boom"), interval=0.001
+        )
+
+
+def test_timeout_raises() -> None:
+    with pytest.raises(PollTimeoutError, match="within 0.1"):
+        poll_until_complete(
+            lambda: _FakeStatus("PENDING"), interval=0.01, timeout=0.1
+        )
+
+
+def test_wrapper_passes_task_id_to_status_getter() -> None:
+    calls: typing.List[typing.Tuple[str, str]] = []
+    client = type("FakeClient", (), _getters(calls))()
+
+    status = poll_dubbing(client, task_id="task-1", interval=0.001)
+
+    assert calls == [("get_dubbing_status", "task-1")]
+    assert status.run_id == 42
+
+
+def test_all_sync_wrappers_dispatch() -> None:
+    for wrapper, getter in [
+        (poll_dubbing, "get_dubbing_status"),
+        (poll_transcription, "get_transcription_task_status"),
+        (poll_subtitle, "get_subtitle_task_status"),
+        (poll_text_to_audio, "get_text_to_audio_status"),
+    ]:
+        calls: typing.List[typing.Tuple[str, str]] = []
+        client = type("FakeClient", (), _getters(calls))()
+        status = wrapper(client, task_id="t", interval=0.001)
+        assert status.status == "SUCCESS"
+        assert calls[-1] == (getter, "t")
+
+
+def test_all_async_wrappers_dispatch() -> None:
+    names = [
+        "get_dubbing_status",
+        "get_transcription_task_status",
+        "get_subtitle_task_status",
+        "get_text_to_audio_status",
+    ]
+
+    def make(name: str):
+        async def aget(self, task_id: str) -> _FakeStatus:
+            return _FakeStatus("SUCCESS", run_id=42)
+
+        return aget
+
+    for wrapper, getter in [
+        (apoll_dubbing, "get_dubbing_status"),
+        (apoll_transcription, "get_transcription_task_status"),
+        (apoll_subtitle, "get_subtitle_task_status"),
+        (apoll_text_to_audio, "get_text_to_audio_status"),
+    ]:
+        got = {}
+
+        async def main() -> None:
+            client = type("FakeAsyncClient", (), {n: make(n) for n in names})()
+            got["status"] = await wrapper(client, task_id="t", interval=0.001)
+
+        _run(main())
+        assert got["status"].status == "SUCCESS"
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def test_async_returns_immediately_on_success() -> None:
+    async def get_status() -> _FakeStatus:
+        return _success()
+
+    async def main() -> None:
+        status = await apoll_until_complete(get_status, interval=0.001)
+        assert status.status == "SUCCESS"
+
+    _run(main())
+
+
+def test_async_polls_until_success() -> None:
+    statuses = iter(["PENDING", "SUCCESS"])
+
+    async def get_status() -> _FakeStatus:
+        return _FakeStatus(next(statuses))
+
+    async def main() -> None:
+        status = await apoll_until_complete(get_status, interval=0.001, timeout=5)
+        assert status.status == "SUCCESS"
+
+    _run(main())
+
+
+def test_async_error_raises_immediately() -> None:
+    async def get_status() -> _FakeStatus:
+        return _FakeStatus("ERROR", message="kaput")
+
+    async def main() -> None:
+        with pytest.raises(PollFailureError, match="kaput"):
+            await apoll_until_complete(get_status, interval=0.001)
+
+    _run(main())
+
+
+def test_async_timeout_raises() -> None:
+    async def get_status() -> _FakeStatus:
+        return _FakeStatus("PENDING")
+
+    async def main() -> None:
+        with pytest.raises(PollTimeoutError):
+            await apoll_until_complete(get_status, interval=0.01, timeout=0.1)
+
+    _run(main())
+
+
+def test_all_async_wrappers_dispatch() -> None:
+    names = [
+        "get_dubbing_status",
+        "get_transcription_task_status",
+        "get_subtitle_task_status",
+        "get_text_to_audio_status",
+    ]
+
+    def make(name: str):
+        async def aget(self, task_id: str) -> _FakeStatus:
+            return _FakeStatus("SUCCESS", run_id=42)
+
+        return aget
+
+    for wrapper, getter in [
+        (apoll_dubbing, "get_dubbing_status"),
+        (apoll_transcription, "get_transcription_task_status"),
+        (apoll_subtitle, "get_subtitle_task_status"),
+        (apoll_text_to_audio, "get_text_to_audio_status"),
+    ]:
+        got = {}
+
+        async def main() -> None:
+            client = type("FakeAsyncClient", (), {n: make(n) for n in names})()
+            got["status"] = await wrapper(client, task_id="t", interval=0.001)
+
+        _run(main())
+        assert got["status"].status == "SUCCESS"
+
+
+def _getters(calls: typing.List[typing.Tuple[str, str]]) -> typing.Dict[str, typing.Any]:
+    names = [
+        "get_dubbing_status",
+        "get_transcription_task_status",
+        "get_subtitle_task_status",
+        "get_text_to_audio_status",
+    ]
+
+    def make(name: str):
+        def get(self, task_id: str) -> _FakeStatus:
+            calls.append((name, task_id))
+            return _FakeStatus("SUCCESS", run_id=42)
+
+        return get
+
+    return {name: make(name) for name in names}
+
+
+def test_poll_exceptions_hierarchy() -> None:
+    assert issubclass(PollTimeoutError, Exception)
+    assert issubclass(PollFailureError, Exception)


### PR DESCRIPTION
## What

Every long-running workflow (dubbing, transcription, subtitles, text-to-audio) forces users to hand-write the poll loop:

```python
while True:
    status = client.dub.get_dubbing_status(task_id=task_id)
    if status.status == "SUCCESS":
        break
    time.sleep(5)
```

Adds a hand-written `camb/polling.py`:

- `poll_until_complete(get_status, *, interval=5, timeout=None)` and async `apoll_until_complete`
- Per-resource wrappers: `poll_dubbing(client.dub, task_id)`, `poll_transcription`, `poll_subtitle`, `poll_text_to_audio` (+ `apoll_*`)
- `PollFailureError` raised immediately on an `ERROR` status, `PollTimeoutError` if no `SUCCESS` before `timeout` (`None` = poll forever) — mirrors the TaskStatus enum (`SUCCESS`/`PENDING`/`ERROR`)

Usage:

```python
from camb.polling import poll_dubbing

status = poll_dubbing(client.dub, task_id=task_id, timeout=600)
result = client.dub.get_dubbed_run_info(status.run_id)
```

Also adds 14 unit tests (immediate success, PENDING→SUCCESS, ERROR/Timeout paths, wrapper dispatch for sync and async) and a README section.

## Why

The poll loop is duplicated across README examples and user code; a helper removes the boilerplate and gives consistent error semantics (the examples silently hang on ERROR/PENDING-forever today).